### PR TITLE
Configuracion del "from" para los emails

### DIFF
--- a/ckanext/gobar_theme/mailer.py
+++ b/ckanext/gobar_theme/mailer.py
@@ -16,7 +16,7 @@ except ImportError:
     sslerror = None
 MailerException = ckan_mailer.MailerException
 
-andino_address = 'no-reply@andino.datos.gob.ar'
+andino_address = config.get('smtp.mail_from')
 
 reset_password_subject = u'Recuperemos tu contraseña de {site_title}'
 


### PR DESCRIPTION
La configuracion del from para los emails es tomada del setting de ckan "smtp.mail_from".

La configuracion actual es "administrador" y debe ser cambiada por cada nodo.

refs:#174