### PR TITLE
Ahora los atributos de la tabla de metadatos se ven en castellano

### DIFF
--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -176,26 +176,26 @@ def json_loads(json_string):
 
 def update_frequencies(freq_id=None):
     frequencies = [
-        ("R/PT1S", "Continuamente actualizado"),
-        ("R/PT1H", "Cada hora"),
-        ("R/P1D", "Diariamente"),
-        ("R/P0.33W", "Tres veces a la semana"),
-        ("R/P0.5W", "Dos veces a la semana"),
-        ("R/P3.5D", "Cada media semana"),
-        ("R/P1W", "Semanalmente"),
-        ("R/P0.33M", "Tres veces por mes"),
-        ("R/P0.5M", "Cada 15 días"),
-        ("R/P1M", "Mensualmente"),
-        ("R/P2M", "Bimestralmente"),
-        ("R/P3M", "Trimestralmente"),
-        ("R/P4M", "Cuatrimestralmente"),
-        ("R/P6M", "Cada medio año"),
-        ("R/P1Y", "Anualmente"),
-        ("R/P2Y", "Cada dos años"),
-        ("R/P3Y", "Cada tres años"),
-        ("R/P4Y", "Cada cuatro años"),
-        ("R/P10Y", "Cada diez años"),
-        ('eventual', 'Eventual')
+        ("R/PT1S", u"Continuamente actualizado"),
+        ("R/PT1H", u"Cada hora"),
+        ("R/P1D", u"Diariamente"),
+        ("R/P0.33W", u"Tres veces a la semana"),
+        ("R/P0.5W", u"Dos veces a la semana"),
+        ("R/P3.5D", u"Cada media semana"),
+        ("R/P1W", u"Semanalmente"),
+        ("R/P0.33M", u"Tres veces por mes"),
+        ("R/P0.5M", u"Cada 15 días"),
+        ("R/P1M", u"Mensualmente"),
+        ("R/P2M", u"Bimestralmente"),
+        ("R/P3M", u"Trimestralmente"),
+        ("R/P4M", u"Cuatrimestralmente"),
+        ("R/P6M", u"Cada medio año"),
+        ("R/P1Y", u"Anualmente"),
+        ("R/P2Y", u"Cada dos años"),
+        ("R/P3Y", u"Cada tres años"),
+        ("R/P4Y", u"Cada cuatro años"),
+        ("R/P10Y", u"Cada diez años"),
+        ('eventual', u'Eventual')
     ]
     if freq_id is not None:
         filtered_freq = filter(lambda freq: freq[0] == freq_id, frequencies)
@@ -205,22 +205,42 @@ def update_frequencies(freq_id=None):
     return frequencies
 
 
-def field_types():
-    return [
-        ("string", "Texto (string)"),
-        ("integer", "Número entero (integer)"),
-        ("number", "Número decimal (number)"),
-        ("boolean", "Verdadero/falso (boolean)"),
-        ("time", "Tiempo ISO-8601 (time)"),
-        ("date", "Fecha ISO-8601 (date)"),
-        ("date-time", "Fecha y hora ISO-8601 (date-time)"),
-        ("object", "JSON (object)"),
-        ("geojson", "GeoJSON (geojson)"),
-        ("geo_point", "GeoPoint (geo_point)"),
-        ("array", "Lista de valores en formato JSON (array)"),
-        ("binary", "Valor binario en base64 (binary)"),
-        ("any", "Otro (any)")
+def field_types(field_type_id=None):
+    field_types = [
+        ("string", u"Texto (string)"),
+        ("integer", u"Número entero (integer)"),
+        ("number", u"Número decimal (number)"),
+        ("boolean", u"Verdadero/falso (boolean)"),
+        ("time", u"Tiempo ISO-8601 (time)"),
+        ("date", u"Fecha ISO-8601 (date)"),
+        ("date-time", u"Fecha y hora ISO-8601 (date-time)"),
+        ("object", u"JSON (object)"),
+        ("geojson", u"GeoJSON (geojson)"),
+        ("geo_point", u"GeoPoint (geo_point)"),
+        ("array", u"Lista de valores en formato JSON (array)"),
+        ("binary", u"Valor binario en base64 (binary)"),
+        ("any", u"Otro (any)")
     ]
+
+    if field_type_id:
+        filtered_field_type = filter(lambda field_type: field_type[0] == field_type_id, field_types)
+        if len(filtered_field_type) > 0:
+            return filtered_field_type[0]
+        return None
+
+    return field_types
+
+
+def special_field_types(special_field_type_id=None):
+    special_field_types = [
+        ("time_index", u"Índice de tiempo"),
+    ]
+    if special_field_type_id is not None:
+        filtered_special_field_type = filter(lambda special_field_type: special_field_type[0] == special_field_type_id, special_field_types)
+        if len(filtered_special_field_type) > 0:
+            return filtered_special_field_type[0]
+        return None
+    return special_field_types
 
 
 def type_is_numeric(field_type):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -48,6 +48,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'json_loads': gobar_helpers.json_loads,
             'update_frequencies': gobar_helpers.update_frequencies,
             'field_types': gobar_helpers.field_types,
+            'special_field_types': gobar_helpers.special_field_types,
             'render_ar_datetime': gobar_helpers.render_ar_datetime,
             'accepted_mime_types': gobar_helpers.accepted_mime_types,
             'package_resources': gobar_helpers.package_resources,

--- a/ckanext/gobar_theme/templates/package/resource_read.html
+++ b/ckanext/gobar_theme/templates/package/resource_read.html
@@ -148,7 +148,7 @@
                                     Frecuencia de actualización
                                 </div>
                                 <div class="col-xs-8 value">
-                                    {{ h.update_frequencies(extra.value)[1].decode('utf-8') or _('unknown') }}
+                                    {{ h.update_frequencies(extra.value)[1] or _('unknown') }}
                                 </div>
                             </div>
                         {% endif %}

--- a/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
@@ -10,7 +10,7 @@
             <select id="update-freq" name="updateFrequency" type="select">
                 <option {{ 'selected=true' if not selected_freq or selected_freq|length == 0 }} disabled="disabled"></option>
                 {% for frequencie in frequencies %}
-                    <option value="{{ frequencie[0] }}" {{ 'selected' if frequencie[0] == selected_freq }}>{{ frequencie[1].decode('utf-8') }}</option>
+                    <option value="{{ frequencie[0] }}" {{ 'selected' if frequencie[0] == selected_freq }}>{{ frequencie[1] }}</option>
                 {% endfor %}
             </select>
         </div>

--- a/ckanext/gobar_theme/templates/package/snippets/resource_attributes_table.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_attributes_table.html
@@ -26,12 +26,33 @@
             {% for attribute_group in attributes %}
                 <tr>
                     <td class="m-title">{{ attribute_group.get('title', '') }}&nbsp;</td>
-                    <td class="m-type">{{ attribute_group.get('type', '') }}&nbsp;</td>
+                    <td class="m-type">
+                        {% set attribute_type = attribute_group.get('type', '') %}
+                        {% if attribute_type %}
+                            {{ h.field_types(attribute_type)[1] }}
+                        {% else %}
+                            &nbsp;
+                        {% endif %}
+                    </td>
                     <td class="m-description">{{ attribute_group.get('description', '') }}&nbsp;</td>
                     <td class="m-units">{{ attribute_group.get('units', '') }}&nbsp;</td>
                     <td class="m-id">{{ attribute_group.get('id', '') }}&nbsp;</td>
-                    <td class="m-specialType">{{ attribute_group.get('specialType', '') }}&nbsp;</td>
-                    <td class="m-specialTypeDetail">{{ attribute_group.get('specialTypeDetail', '') }}&nbsp;</td>
+                    <td class="m-specialType">
+                        {% set special_type = attribute_group.get('specialType', '') %}
+                        {% if special_type %}
+                            {{ h.special_field_types(special_type)[1] }}
+                        {% else %}
+                            &nbsp;
+                        {% endif %}
+                    </td>
+                    <td class="m-specialTypeDetail">
+                        {% set special_type_detail = attribute_group.get('specialTypeDetail', '') %}
+                        {% if special_type_detail %}
+                            {{ h.update_frequencies(special_type_detail)[1] }}
+                        {% else %}
+                            &nbsp;
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form_attributes.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form_attributes.html
@@ -37,7 +37,7 @@
                             </option>
                             {% for field_type in h.field_types() %}
                                 <option value="{{ field_type[0] }}" {{ 'selected=true' if field_type[0] == selected_type }}
-                                >{{ field_type[1].decode('utf-8') }}</option>
+                                >{{ field_type[1] }}</option>
                             {% endfor %}
                         </select>
                     </div>
@@ -81,11 +81,15 @@
                 <div class="col-xs-6 resource-attributes-input-container resource-col-special-data-container">
                     <label class="control-label">Tipo de dato especial</label>
                     <div class="controls">
+                        {% set special_types = h.special_field_types() %}
                         {% set selected_special_type = attribute_group['specialType'] %}
-                        {% set time_index_value = "time_index" %}
                         <select class="resource-col-special-data">
-                            <option></option>
-                            <option value="time_index" {{ 'selected' if time_index_value == selected_special_type }}>Indice de tiempo</option>
+                                <option {{ 'selected=true' if not selected_special_type or selected_special_type|length == 0 }}
+                                    disabled="disabled">Ej.: Índice de tiempo
+                                </option>
+                            {% for special_type in special_types %}
+                            <option value="{{ special_type[0] }}" {{ 'selected' if special_type[0] == selected_special_type }}>{{ special_type[1] }}</option>
+                            {% endfor %}
                         </select>
                     </div>
                 </div>
@@ -95,10 +99,11 @@
                     <div class="controls">
                         {% set frequencies = h.update_frequencies() %}
                         {% set selected_freq = attribute_group['specialTypeDetail'] %}
+                        {% set time_index_value = 'time_index' %}
                         <select class="resource-col-special-data-detail" {{ 'disabled' if time_index_value != selected_special_type }}>
                             <option {{ 'selected=true' if not selected_freq or selected_freq|length == 0 }}></option>
                             {% for frequencie in frequencies %}
-                                <option value="{{ frequencie[0] }}" {{ 'selected' if frequencie[0] == selected_freq }}>{{ frequencie[1].decode('utf-8') }}</option>
+                                <option value="{{ frequencie[0] }}" {{ 'selected' if frequencie[0] == selected_freq }}>{{ frequencie[1] }}</option>
                             {% endfor %}
                         </select>
                     </div>

--- a/ckanext/gobar_theme/templates/package/snippets/secondary_info.html
+++ b/ckanext/gobar_theme/templates/package/snippets/secondary_info.html
@@ -74,7 +74,7 @@
                             Frecuencia de actualización
                         </div>
                         <div class="col-xs-7 value">
-                            <p>{{ h.update_frequencies(extra.value)[1].decode('utf-8') }}</p>
+                            <p>{{ h.update_frequencies(extra.value)[1] }}</p>
                         </div>
                     </div>
                 {% endif %}


### PR DESCRIPTION
Agregué al template de la tabla lógica para convertir el `value` guardado al valor en castellano. Para ello tuve que:

* Agrego filtro al helper que devuelve los `field_types`.
* Agrego helper que devuelve los `special_field_types`.
* Los helpers mencionados arriba y `update_frequencies` devuelven strings `unicode`.
* Dado el cambio anterior, tuve que modificar algunos templates donde convertían a mano los bytestrings a `unicode`.

closes #173