### PR TITLE
175 fusion andino datosgobar documentacion de apis

### DIFF
--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -19,7 +19,8 @@ NotAuthorized = logic.NotAuthorized
 
 
 class GobArConfigController(base.BaseController):
-    IMG_DIR = '/usr/lib/ckan/default/src/ckanext-gobar-theme/ckanext/gobar_theme/public/user_images/'
+    #IMG_DIR = '/usr/lib/ckan/default/src/ckanext-gobar-theme/ckanext/gobar_theme/public/user_images/'
+    IMG_DIR = '/theme/ckanext/gobar_theme/public/user_images/'
     CONFIG_PATH = '/var/lib/ckan/theme_config/settings.json'
 
     def edit_title(self):

--- a/ckanext/gobar_theme/js/forms/autovalidations/urls.js
+++ b/ckanext/gobar_theme/js/forms/autovalidations/urls.js
@@ -9,29 +9,25 @@ $(function() {
         var HEADER_HEIGHT = $('#header').height();
 
         $(event.target).find('input.url-field[type=text], div.url-field > div > input[type=text]').each(function(index) {
-            if (!($('select#distribution-type').children("option").filter(":selected").text() === 'API' && $(this).attr('name') === 'icon_url')){
-                // no quiero validar el contenido del input si sé que éste está siendo usado para guardar una imagen
-                if ( !$('input').is('[readonly]') ){
-                    // Si la validación falla, abortar el submit y mostrar un mensaje de validación
-                    var that = $(this);
-                    if (that.val() && !that.val().match(URL_VALIDATION_REGEX)) {
-                        // Agrego el mensaje de error
+            if ( !$('input').is('[readonly]') ){
+                // Si la validación falla, abortar el submit y mostrar un mensaje de validación
+                var that = $(this);
+                if (that.val() && !that.val().match(URL_VALIDATION_REGEX)) {
+                    // Agrego el mensaje de error
 
-                        if (!that.data('validation-failed')) {
-                            var errorMessageTemplate = '<label for="' + (that.attr('id') || '') + '" class="form-error-message">La url ingresada no es válida</label>';
-                            that.after(errorMessageTemplate);
-// todo: prependear la url de localhost en el input del icono (ya se hace en el archivo del recurso)
-                            $('html, body').animate({
-                                scrollTop: (that.first().offset().top - HEADER_HEIGHT)
-                            }, 500);
+                    if (!that.data('validation-failed')) {
+                        var errorMessageTemplate = '<label for="' + (that.attr('id') || '') + '" class="form-error-message">La url ingresada no es válida</label>';
+                        that.after(errorMessageTemplate);
+                        $('html, body').animate({
+                            scrollTop: (that.first().offset().top - HEADER_HEIGHT)
+                        }, 500);
 
-                            that.data('validation-failed', true);
-                        }
-
-                        event.preventDefault();  // Evitamos que el form haga el submit
-                    } else {
-                        that.data('validation-failed', false);
+                        that.data('validation-failed', true);
                     }
+
+                    event.preventDefault();  // Evitamos que el form haga el submit
+                } else {
+                    that.data('validation-failed', false);
                 }
             }
         });

--- a/ckanext/gobar_theme/js/forms/autovalidations/urls.js
+++ b/ckanext/gobar_theme/js/forms/autovalidations/urls.js
@@ -9,26 +9,29 @@ $(function() {
         var HEADER_HEIGHT = $('#header').height();
 
         $(event.target).find('input.url-field[type=text], div.url-field > div > input[type=text]').each(function(index) {
-            if ( !$('input').is('[readonly]') ){
-                // Si la validación falla, abortar el submit y mostrar un mensaje de validación
-                var that = $(this);
-                if (that.val() && !that.val().match(URL_VALIDATION_REGEX)) {
-                    // Agrego el mensaje de error
+            if (!($('select#distribution-type').children("option").filter(":selected").text() === 'API' && $(this).attr('name') === 'icon_url')){
+                // no quiero validar el contenido del input si sé que éste está siendo usado para guardar una imagen
+                if ( !$('input').is('[readonly]') ){
+                    // Si la validación falla, abortar el submit y mostrar un mensaje de validación
+                    var that = $(this);
+                    if (that.val() && !that.val().match(URL_VALIDATION_REGEX)) {
+                        // Agrego el mensaje de error
 
-                    if (!that.data('validation-failed')) {
-                        var errorMessageTemplate = '<label for="' + (that.attr('id') || '') + '" class="form-error-message">La url ingresada no es válida</label>';
-                        that.after(errorMessageTemplate);
+                        if (!that.data('validation-failed')) {
+                            var errorMessageTemplate = '<label for="' + (that.attr('id') || '') + '" class="form-error-message">La url ingresada no es válida</label>';
+                            that.after(errorMessageTemplate);
+// todo: prependear la url de localhost en el input del icono (ya se hace en el archivo del recurso)
+                            $('html, body').animate({
+                                scrollTop: (that.first().offset().top - HEADER_HEIGHT)
+                            }, 500);
 
-                        $('html, body').animate({
-                            scrollTop: (that.first().offset().top - HEADER_HEIGHT)
-                        }, 500);
+                            that.data('validation-failed', true);
+                        }
 
-                        that.data('validation-failed', true);
+                        event.preventDefault();  // Evitamos que el form haga el submit
+                    } else {
+                        that.data('validation-failed', false);
                     }
-
-                    event.preventDefault();  // Evitamos que el form haga el submit
-                } else {
-                    that.data('validation-failed', false);
                 }
             }
         });

--- a/ckanext/gobar_theme/js/forms/upload_input_fix.js
+++ b/ckanext/gobar_theme/js/forms/upload_input_fix.js
@@ -35,6 +35,7 @@ this.ckan.module('gobar-image-upload', function($, _) {
       var field_clear = 'input[name="' + options.field_clear + '"]';
 
       this.input = $(field_upload, this.el);
+      this.input.addClass('field-image-upload');
       this.field_url = $(field_url, this.el).parents('.control-group');
       this.field_image = this.input.parents('.control-group');
       this.field_url_input = $('input', this.field_url);
@@ -59,7 +60,7 @@ this.ckan.module('gobar-image-upload', function($, _) {
         .insertAfter(this.input);
 
       // Button to attach local file to the form
-      this.button_upload = $('<label for="field-image-upload" class="file-upload-label">' +
+      this.button_upload = $('<label for=' + this.input.attr('id') + ' class="file-upload-label">' +
           '<span class="btn upload-btn">'+this.i18n('upload')+'</span>' +
         '</label>')
         .on('click', this.file_upload_label_actions)
@@ -109,12 +110,19 @@ this.ckan.module('gobar-image-upload', function($, _) {
 
     url_button_actions: function() {
       $('#form-file-name').css("display", "inline-block");
+
+      // TODO: Este script es propio del formulario de resource. No corresponde a este script.
       $('option.distribution-type-option[value="file.upload"]').val('file');
     },
 
     file_upload_label_actions: function() {
-      $('#form-file-name').css("display", "none");
-      $('option.distribution-type-option[value="file"]').val('file.upload');
+      $('input#' + $( event.target ).parent().attr('for')).click();  // Disparo el click en el input[type=file]
+
+      // TODO: Este script es propio del formulario de resource. No corresponde a este script.
+      if($('form#resource-edit').length > 0){
+        $('#form-file-name').css("display", "none");
+        $('option.distribution-type-option[value="file"]').val('file.upload');
+      }
     },
 
     /* Event listener for resetting the field back to the blank state

--- a/ckanext/gobar_theme/js/forms/upload_input_fix.js
+++ b/ckanext/gobar_theme/js/forms/upload_input_fix.js
@@ -52,18 +52,16 @@ this.ckan.module('gobar-image-upload', function($, _) {
         .appendTo(this.el);
 
       // Button to set the field to be a URL
-      this.button_url = $('<span class="btn url-btn">'+this.i18n('url')+'</span>')
+      this.button_url = $('<span class="btn url-btn url-button">'+this.i18n('url')+'</span>')
         .prop('title', this.i18n('url_tooltip'))
         .prop('id', 'url-button')
         .on('click', this._onFromWeb)
-        .on('click', this.url_button_actions)
         .insertAfter(this.input);
 
       // Button to attach local file to the form
       this.button_upload = $('<label for=' + this.input.attr('id') + ' class="file-upload-label">' +
           '<span class="btn upload-btn">'+this.i18n('upload')+'</span>' +
         '</label>')
-        .on('click', this.file_upload_label_actions)
         .insertAfter(this.input);
 
       // Button for resetting the form when there is a URL set
@@ -105,23 +103,6 @@ this.ckan.module('gobar-image-upload', function($, _) {
       this.field_url_input.focus();
       if (this.options.is_upload) {
         this.field_clear.val('true');
-      }
-    },
-
-    url_button_actions: function() {
-      $('#form-file-name').css("display", "inline-block");
-
-      // TODO: Este script es propio del formulario de resource. No corresponde a este script.
-      $('option.distribution-type-option[value="file.upload"]').val('file');
-    },
-
-    file_upload_label_actions: function() {
-      $('input#' + $( event.target ).parent().attr('for')).click();  // Disparo el click en el input[type=file]
-
-      // TODO: Este script es propio del formulario de resource. No corresponde a este script.
-      if($('form#resource-edit').length > 0){
-        $('#form-file-name').css("display", "none");
-        $('option.distribution-type-option[value="file"]').val('file.upload');
       }
     },
 

--- a/ckanext/gobar_theme/js/package/resource/form_actions.js
+++ b/ckanext/gobar_theme/js/package/resource/form_actions.js
@@ -74,7 +74,8 @@ $(function () {
         if(selected_type === 'api'){
             $('#resource-attributes-form').hide();
             hideAndEmpty($('#form-format'));
-            $('#form-licence').show();
+            hideAndEmpty($('#form-file-name'));
+            $('#form-license').show();
             $('a.btn-remove-url').click();
             $('input[type=file]#field-image-upload').val('');
             $('span#url-button').click();
@@ -83,7 +84,7 @@ $(function () {
         else if(selected_type === 'code'){
             $('#resource-attributes-form').hide();
             hideAndEmpty($('#form-format'));
-            hideAndEmpty($('#form-licence'));
+            hideAndEmpty($('#form-license'));
             hideAndEmpty($('#form-file-name'));
             $('i.icon-remove').click();
             $('input[type=file]#field-image-upload').val('');
@@ -92,7 +93,7 @@ $(function () {
         else if(selected_type === 'documentation'){
             $('#resource-attributes-form').hide();
             $('#form-format').show();
-            hideAndEmpty($('#form-licence'));
+            hideAndEmpty($('#form-license'));
             hideAndEmpty($('#form-file-name'));
             $('i.icon-remove').click();
             $('input[type=file]#field-image-upload').val('');
@@ -101,7 +102,7 @@ $(function () {
         else if(selected_type === 'file.upload' || selected_type === 'file'){
             $('#resource-attributes-form').show();
             $('#form-format').show();
-            $('#form-licence').show();
+            $('#form-license').show();
             hideAndEmpty($('#form-file-name'));
             $('i.icon-remove').click();
             $('input[type=file]#field-image-upload').val('');

--- a/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
+++ b/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
@@ -1,17 +1,14 @@
 $(function () {
 
-    alert("HOLA");
-
     $(document).on('click', '.url-button', function () {
-        alert('Click en botón ENLACE');
         $('#form-file-name').css("display", "inline-block");
         $('option.distribution-type-option[value="file.upload"]').val('file');
     });
 
     $(document).on('click', '.file-upload-label', function () {
-        alert('Click en botón SUBIR');
         $('input#' + $(event.target).parent().attr('for')).click();  // Disparo el click en el input[type=file]
         $('#form-file-name').css("display", "none");
         $('option.distribution-type-option[value="file"]').val('file.upload');
     });
+
 });

--- a/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
+++ b/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
@@ -1,0 +1,17 @@
+$(function () {
+
+    alert("HOLA");
+
+    $(document).on('click', '.url-button', function () {
+        alert('Click en botón ENLACE');
+        $('#form-file-name').css("display", "inline-block");
+        $('option.distribution-type-option[value="file.upload"]').val('file');
+    });
+
+    $(document).on('click', '.file-upload-label', function () {
+        alert('Click en botón SUBIR');
+        $('input#' + $(event.target).parent().attr('for')).click();  // Disparo el click en el input[type=file]
+        $('#form-file-name').css("display", "none");
+        $('option.distribution-type-option[value="file"]').val('file.upload');
+    });
+});

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -1,3 +1,4 @@
+from uploader import GobArThemeResourceUploader
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.plugins import implements, IRoutes
@@ -11,6 +12,16 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
     implements(IRoutes, inherit=True)
     implements(plugins.ITemplateHelpers)
     implements(plugins.IActions)
+    implements(plugins.IUploader)
+
+    def get_resource_uploader(self, data_dict):
+        return GobArThemeResourceUploader(data_dict)
+
+    def get_uploader(self, *_):
+        '''
+        No nos interesa proveer un uploader para el plugin, se usa el default de CKAN.
+        '''
+        return None
 
     def get_actions(self):
         return {'package_activity_list_html': gobar_actions.package_activity_list_html,

--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -10045,10 +10045,10 @@ ul.activity {
         #template-config #navbar .links-section.guide-link a:hover i, #template-config #navbar .links-section.guide-link a:hover .blue {
           color: #17b2f8; }
 
-#new-group-container #new-group form .control-group #field-image-upload,
-#edit-group-container #edit-group form .control-group #field-image-upload,
-#new-package-container #new-package form .control-group #field-image-upload,
-#edit-package-container #edit-package form .control-group #field-image-upload {
+#new-group-container #new-group form .control-group .field-image-upload,
+#edit-group-container #edit-group form .control-group .field-image-upload,
+#new-package-container #new-package form .control-group .field-image-upload,
+#edit-package-container #edit-package form .control-group .field-image-upload {
   left: -99999px; }
 #new-group-container #new-group form .control-group .file-upload-label,
 #edit-group-container #edit-group form .control-group .file-upload-label,
@@ -10281,7 +10281,7 @@ div.section-div{
     border-radius: 4px;
 }
 
-.js .image-upload #icon-image-upload {
+.js .image-upload #icon-image-upload, .field-image-upload {
   left: -99999px;
   cursor: pointer;
   position: absolute;

--- a/ckanext/gobar_theme/templates/group/snippets/group_form.html
+++ b/ckanext/gobar_theme/templates/group/snippets/group_form.html
@@ -28,7 +28,7 @@
             <p class="img-description">
                 Por favor, subí solo imágenes en .SVG, sin contenidos ocultos.
             </p>
-            {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=' ', url_label=' ') }}
+            {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label=' ', url_label=' ', id_prefix='icon') }}
         {% endif %}
 
     {% endblock %}

--- a/ckanext/gobar_theme/templates/macros/form.html
+++ b/ckanext/gobar_theme/templates/macros/form.html
@@ -489,10 +489,10 @@ Example
              data-module-field_clear="{{ field_clear }}" data-module-upload_label="{{ upload_label }}">
     {% endif %}
 
-{{ input(field_url, label=url_label, id=id_prefix + '-url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full', 'url-field'], for_label=false) }}
+{{ input(field_url, label=url_label, id=id_prefix + '-upload-url', placeholder=placeholder, value=data.get(field_url), error=errors.get(field_url), classes=['control-full', 'url-field'], for_label=false) }}
 
 {% if is_upload_enabled %}
-    {{ input(field_upload, label=upload_label, id=id_prefix + '-upload', type='file', placeholder='', value='', error='', classes=['control-full'], for_label=false) }}
+    {{ input(field_upload, label=upload_label, id=id_prefix + '-upload-url', type='file', placeholder='', value='', error='', classes=['control-full'], for_label=false) }}
     {% if is_upload %}
         {{ checkbox(field_clear, label=_('Clear Upload'), id='field-clear-upload', value='true', error='', classes=['control-full']) }}
     {% endif %}

--- a/ckanext/gobar_theme/templates/package/resource_read.html
+++ b/ckanext/gobar_theme/templates/package/resource_read.html
@@ -38,7 +38,7 @@
                     <p>{{ res.description }}</p>
                 </div>
                 <div class="col-md-2 col-xs-12 resource-actions">
-                    <a class="btn btn-green btn-block" href="{{ res.url }}">DESCARGAR</a>
+                    <a class="btn btn-green btn-block" href="{{ res.url }}">{{ 'DESCARGAR' if res.resource_type != 'api' else 'A DEFINIR' }}</a>
 
                     {% set distribution_metadata = h.get_distribution_metadata(ds_identifier=pkg.id, resource_title=res.name) %}
                     {% if not h.is_distribution_local(distribution_metadata) %}

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form.html
@@ -183,3 +183,4 @@
 {% resource 'gobar_js/package/resource/form_actions.js' %}
 {% resource 'gobar_js/forms/confirm_delete.js' %}
 {% resource 'gobar_js/forms/autovalidations/urls.js' %}
+{% resource 'gobar_js/package/resource/urls_and_icons.js' %}

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form.html
@@ -71,14 +71,14 @@
             {% set is_upload = (data.url_type == 'upload') %}
             {{ form.image_upload(data, errors, field_url='url', field_upload='upload', field_clear='clear_upload',
          is_upload_enabled=h.uploads_enabled(), is_url=data.url and not is_upload, is_upload=is_upload,
-         upload_label=_('File'), url_label=_('URL')) }}
+         upload_label=_('File'), url_label=_('URL'), id_prefix='resource') }}
 
             {% set resource_type = data.get('resource_type') %}
             <div id="form-icon-url" style="{{ 'display: none;' if resource_type != 'api'}}">
                 {% set icon_is_upload = false %}
                 {{ form.image_upload(data, errors, field_url='icon_url', field_upload='icon_upload', field_clear='clear_icon_upload',
                 is_upload_enabled=h.uploads_enabled(), is_url=not icon_is_upload, is_upload=icon_is_upload,
-                upload_label='Ícono', url_label=_('URL del Ícono'), id_prefix='icon-image') }}
+                upload_label='Ícono', url_label=_('URL del Ícono'), id_prefix='icon') }}
             </div>
 
             <div id="form-file-name" style="display: none">

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form_license.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form_license.html
@@ -1,4 +1,4 @@
-<div class="control-group form-licence">
+<div class="control-group form-licence" id="form-license">
     <label class="control-label" for="field-license">Licencia</label>
     <p>
         Esta licencia aplica para los contenidos del recurso. Cuando publiques, aceptarás liberar los metadatos del

--- a/ckanext/gobar_theme/uploader.py
+++ b/ckanext/gobar_theme/uploader.py
@@ -1,0 +1,88 @@
+#! coding: utf-8
+from ckan.lib import uploader
+import os
+import cgi
+import pylons
+import ckan.lib.munge as munge
+
+from config_controller import GobArConfigController
+
+config = pylons.config
+
+_storage_path = None
+_ufs = None
+
+class GobArThemeResourceUploader(uploader.ResourceUpload):
+
+    def __init__(self, data_dict):
+        super(GobArThemeResourceUploader, self).__init__(data_dict)
+
+        # Hacer el init para el ícono `icon_upload`
+
+        path = self.get_storage_path()
+        if not path:
+            self.storage_path = None
+            return
+        self.storage_path = os.path.join(path, 'resources')
+        try:
+            os.makedirs(self.storage_path)
+        except OSError, e:
+            # errno 17 is file already exists
+            if e.errno != 17:
+                raise
+        self.filename = None
+
+        resource_id = data_dict.get('id')
+        upload_field_storage = data_dict.pop('icon_upload', None)
+        self.clear = data_dict.pop('clear_icon_upload', None)
+
+        if isinstance(upload_field_storage, cgi.FieldStorage):
+            self.filename = '%s-%s' % (resource_id, upload_field_storage.filename)
+            self.upload_file = upload_field_storage.file
+
+            data_dict['icon_url'] = '/user_images/%s' % self.filename
+            data_dict['icon_url_type'] = 'upload'
+        elif self.clear:
+            data_dict['icon_url_type'] = ''
+
+    def upload(self, id, max_size=10):
+        super(GobArThemeResourceUploader, self).upload(id, max_size)
+
+        if not self.storage_path or not self.filename:
+            return
+
+        # Hacer el upload para el ícono
+        output_path = os.path.join(GobArConfigController.IMG_DIR, self.filename)
+        output_file = open(output_path, 'wb')
+        upload_file = self.upload_file
+        upload_file.seek(0)
+        while True:
+            data = upload_file.read(2 ** 20)
+            if not data:
+                break
+            output_file.write(data)
+        output_file.close()
+        return
+
+
+
+
+
+
+    def get_storage_path(self):
+        global _storage_path
+
+        # None means it has not been set. False means not in config.
+        if _storage_path is None:
+            storage_path = config.get('ckan.storage_path')
+            ofs_impl = config.get('ofs.impl')
+            ofs_storage_dir = config.get('ofs.storage_dir')
+            if storage_path:
+                _storage_path = storage_path
+            elif ofs_impl == 'pairtree' and ofs_storage_dir:
+                _storage_path = ofs_storage_dir
+                return _storage_path
+            else:
+                _storage_path = False
+
+        return _storage_path

--- a/ckanext/gobar_theme/uploader.py
+++ b/ckanext/gobar_theme/uploader.py
@@ -12,6 +12,7 @@ config = pylons.config
 _storage_path = None
 _ufs = None
 
+
 class GobArThemeResourceUploader(uploader.ResourceUpload):
 
     def __init__(self, data_dict):
@@ -40,7 +41,7 @@ class GobArThemeResourceUploader(uploader.ResourceUpload):
             self.filename = '%s-%s' % (resource_id, upload_field_storage.filename)
             self.upload_file = upload_field_storage.file
 
-            data_dict['icon_url'] = '/user_images/%s' % self.filename
+            data_dict['icon_url'] = config.get('ckan.site_url') + '/user_images/%s' % self.filename
             data_dict['icon_url_type'] = 'upload'
         elif self.clear:
             data_dict['icon_url_type'] = ''
@@ -63,11 +64,6 @@ class GobArThemeResourceUploader(uploader.ResourceUpload):
             output_file.write(data)
         output_file.close()
         return
-
-
-
-
-
 
     def get_storage_path(self):
         global _storage_path


### PR DESCRIPTION
* Guardo íconos para los recursos de tipo API.
* Corrijo funcionalidad para esconder o mostrar los campos 'Licencia' y 'Nombre del archivo'.

El texto para el botón de la vista de un recurso queda a definir (caso: recursos de tipo API).