### PR TITLE
Escondo la tabla de metadatos en la vista de un recurso si se está en…

### DIFF
--- a/ckanext/gobar_theme/templates/package/resource_read.html
+++ b/ckanext/gobar_theme/templates/package/resource_read.html
@@ -47,7 +47,7 @@
                     {% endif %}
                 </div>
 
-                <div class="resource-previsualization" style="display: {{ block if res.datastore_active else none }}">
+                <div class="resource-previsualization hidden-xs hidden-sm" style="display: {{ block if res.datastore_active else none }}">
                     <div class="resource-additional-info col-xs-12 col-md-12 row"
                          style="border-bottom: 0; width: 103%; margin-bottom: 20px; margin-top: 30px;">
                         <h2 class="title-h" style="padding-bottom: 0 !important;">Previsualización</h2>
@@ -100,7 +100,7 @@
                     </div>
                 </div>
 
-                <div class="col-xs-12 col-md-12 row">
+                <div class="col-xs-12 col-md-12 row hidden-xs hidden-sm">
                     {% snippet "package/snippets/resource_attributes_table.html", res=res %}
                 </div>
 


### PR DESCRIPTION
… mobile. También el título 'Previsualización', ya que su tabla estaba siendo escondida.