### PR TITLE
Fix al crear/actualizar la caché del datajson

### DIFF
--- a/ckanext/gobar_theme/templates/datajson.html
+++ b/ckanext/gobar_theme/templates/datajson.html
@@ -27,10 +27,10 @@
     {% if datajson.rights %}
         "rights": {{ h.jsondump(datajson.rights) }},
     {% endif %}
-    {% if datajson.spatial %}
+    {% if datajson.spatial is defined %}
         "spatial": {{ h.jsondump(datajson.spatial) }},
     {% endif %}
-    {% if datajson.themeTaxonomy %}
+    {% if datajson.themeTaxonomy is defined %}
         "themeTaxonomy": {{ h.jsondump(datajson.themeTaxonomy) }},
     {% endif %}
     "dataset":


### PR DESCRIPTION
Si los campos spatial o themeTaxonomy del catalog estaban vacíos, no se guardaban.