### PR TITLE
Arreglo el color de los íconos

### DIFF
--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -7191,7 +7191,7 @@ div#background-container {
           top: 50%;
           left: 10px;
           margin-top: -17.5px; }
-          .featured-groups .group-container .group .group-text svg path, .featured-groups .group-container .group .group-text img path {
+          .featured-groups .group-container .group .group-text svg circle, .featured-groups .group-container .group .group-text svg path, .featured-groups .group-container .group .group-text img path {
             fill: #0695d6; }
         .featured-groups .group-container .group .group-text .group-table {
           width: 100%;
@@ -8485,9 +8485,9 @@ div#background-container {
           max-height: 35px; }
           .filters-container .search-filter .group-images .group-image-container svg path {
             fill: #cccccc; }
-        .filters-container .search-filter .group-images .group-image-container.available svg path {
+            .filters-container .search-filter .group-images .group-image-container.available svg circle, .filters-container .search-filter .group-images .group-image-container.available svg path {
           fill: #767676; }
-        .filters-container .search-filter .group-images .group-image-container.available:hover svg path {
+          .filters-container .search-filter .group-images .group-image-container.available:hover svg circle, .filters-container .search-filter .group-images .group-image-container.available:hover svg path {
           fill: #0695d6; }
         .filters-container .search-filter .group-images .group-image-container.active svg path {
           fill: #0695d6; }


### PR DESCRIPTION
Los colores de los íconos con `svg circle` ahora están alineados con los demás íconos.

Es necesario reemplazar el svg de `soci` por el siguiente:

```
<svg id="Capa_1" data-name="Capa 1"
	xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41 24.5">
	<title>00_Portal de Datos_poblacion-sociedad</title>
	<style type="text/css">
		.svg-poblacion-sociedad{fill:#767676;}
	</style>
	<circle class="svg-poblacion-sociedad" cx="21.5" cy="6.2" r="6.2" />
	<circle class="svg-poblacion-sociedad" cx="33.3" cy="8.2" r="4" />
	<path class="svg-poblacion-sociedad" d="M41,18.1c0-2.6-5.1-4-7.8-4a12.75,12.75,0,0,0-6.7,2,19.31,19.31,0,0,0-5-.7,21.41,21.41,0,0,0-6.1,1c-1.6-1.5-5.3-2.3-7.3-2.3-2.7,0-8.1,1.3-8.1,4v4.4H9v2H34v-2h7V18.1Z" transform="translate(0)" />
	<circle class="svg-poblacion-sociedad" cx="8.3" cy="8.2" r="4" />
</svg>
```

Porque el actual tiene estilos inline que generan problemas

close #243 