### PR TITLE
Configuración para limpieza de cache

### DIFF
--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -12,6 +12,7 @@ import moment
 import redis
 from ckan.common import request, c
 from pylons import config as ckan_config
+import ckanext.gobar_theme.lib.cache_actions as cache_actions
 
 parse_params = logic.parse_params
 abort = base.abort
@@ -61,6 +62,7 @@ class GobArConfigController(base.BaseController):
             # Se importa 'datajson_actions' en la función para evitar dependencias circulares con 'config_controller'
             import ckanext.gobar_theme.lib.datajson_actions as datajson_actions
             datajson_actions.enqueue_update_datajson_cache_tasks()
+            cache_actions.clear_web_cache()
 
         return base.render('config/config_01_title.html')
 
@@ -122,6 +124,7 @@ class GobArConfigController(base.BaseController):
             self._set_config(config_dict)
         import ckanext.gobar_theme.lib.datajson_actions as datajson_actions
         datajson_actions.enqueue_update_datajson_cache_tasks()
+        cache_actions.clear_web_cache()
 
         return base.render('config/config_05_social.html')
 
@@ -250,6 +253,7 @@ class GobArConfigController(base.BaseController):
             # Se importa 'datajson_actions' en la función para evitar dependencias circulares con 'config_controller'
             import ckanext.gobar_theme.lib.datajson_actions as datajson_actions
             datajson_actions.enqueue_update_datajson_cache_tasks()
+            cache_actions.clear_web_cache()
         return base.render(template_name='config/config_12_metadata_portal.html')
 
     def edit_apis(self):

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -12,7 +12,7 @@ import moment
 import redis
 from ckan.common import request, c
 from pylons import config as ckan_config
-import ckanext.gobar_theme.lib.cache_actions as cache_actions
+from ckanext.gobar_theme.lib import cache_actions
 
 parse_params = logic.parse_params
 abort = base.abort

--- a/ckanext/gobar_theme/lib/cache_actions.py
+++ b/ckanext/gobar_theme/lib/cache_actions.py
@@ -7,12 +7,14 @@ from pylons import config
 
 logger = logging.getLogger(__name__)
 
+
 def clear_web_cache():
     cache_clean_hook = config.get('andino.cache_clean_hook')
+    cache_clean_hook_method = config.get('andino.cache_clean_hook_method')
     if cache_clean_hook is not None:
         try:
-            response_for_http_request = requests.get(cache_clean_hook, timeout=2)
+            response_for_http_request = requests.request(cache_clean_hook_method, cache_clean_hook, timeout=2)
             response_for_http_request.raise_for_status()
         except Exception as e:
-            logger.info(u'Hubo un problema limpiando la caché del servicio web con el request a la url %s: %s ', \
+            logger.info(u'Hubo un problema limpiando la caché del servicio web con el request a la url %s: %s ',
                         cache_clean_hook, e)

--- a/ckanext/gobar_theme/lib/cache_actions.py
+++ b/ckanext/gobar_theme/lib/cache_actions.py
@@ -13,7 +13,8 @@ def clear_web_cache():
     cache_clean_hook_method = config.get('andino.cache_clean_hook_method')
     if cache_clean_hook is not None:
         try:
-            response_for_http_request = requests.request(cache_clean_hook_method, cache_clean_hook, timeout=2)
+            response_for_http_request = \
+                requests.request(cache_clean_hook_method or 'PURGE', cache_clean_hook, timeout=2)
             response_for_http_request.raise_for_status()
         except Exception as e:
             logger.info(u'Hubo un problema limpiando la caché del servicio web con el request a la url %s: %s ',

--- a/ckanext/gobar_theme/lib/cache_actions.py
+++ b/ckanext/gobar_theme/lib/cache_actions.py
@@ -1,10 +1,13 @@
 import requests
+from pylons import config
 
 
-def clear_web_cache(url):
-    try:
-        response_for_http_request = requests.get(url, timeout=2)
-        response_for_http_request.raise_for_status()
-    except requests.exceptions.HTTPError:
-        # Hubo un problema con el request
-        pass
+def clear_web_cache():
+    cache_clean_hook = config.get('andino.cache_clean_hook')
+    if cache_clean_hook is not None:
+        try:
+            response_for_http_request = requests.get(cache_clean_hook, timeout=2)
+            response_for_http_request.raise_for_status()
+        except requests.exceptions.HTTPError:
+            # Hubo un problema con el request
+            pass

--- a/ckanext/gobar_theme/lib/cache_actions.py
+++ b/ckanext/gobar_theme/lib/cache_actions.py
@@ -1,0 +1,10 @@
+import requests
+
+
+def clear_web_cache(url):
+    try:
+        response_for_http_request = requests.get(url, timeout=2)
+        response_for_http_request.raise_for_status()
+    except requests.exceptions.HTTPError:
+        # Hubo un problema con el request
+        pass

--- a/ckanext/gobar_theme/lib/cache_actions.py
+++ b/ckanext/gobar_theme/lib/cache_actions.py
@@ -1,6 +1,9 @@
-from pylons import config
+#! coding: utf-8
 import requests
 import logging
+
+from pylons import config
+
 
 logger = logging.getLogger(__name__)
 
@@ -10,5 +13,6 @@ def clear_web_cache():
         try:
             response_for_http_request = requests.get(cache_clean_hook, timeout=2)
             response_for_http_request.raise_for_status()
-        except requests.exceptions.HTTPError:
-            logger.info('Hubo un problema con el request a la url ' + cache_clean_hook)
+        except Exception as e:
+            logger.info(u'Hubo un problema limpiando la caché del servicio web con el request a la url %s: %s ', \
+                        cache_clean_hook, e)

--- a/ckanext/gobar_theme/lib/cache_actions.py
+++ b/ckanext/gobar_theme/lib/cache_actions.py
@@ -1,6 +1,8 @@
-import requests
 from pylons import config
+import requests
+import logging
 
+logger = logging.getLogger(__name__)
 
 def clear_web_cache():
     cache_clean_hook = config.get('andino.cache_clean_hook')
@@ -9,5 +11,4 @@ def clear_web_cache():
             response_for_http_request = requests.get(cache_clean_hook, timeout=2)
             response_for_http_request.raise_for_status()
         except requests.exceptions.HTTPError:
-            # Hubo un problema con el request
-            pass
+            logger.info('Hubo un problema con el request a la url ' + cache_clean_hook)

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -11,8 +11,6 @@ import ckanext.gobar_theme.routing as gobar_routes
 import ckanext.gobar_theme.actions as gobar_actions
 import ckanext.gobar_theme.lib.datajson_actions as datajson_actions
 import ckanext.gobar_theme.lib.cache_actions as cache_actions
-from pylons import config
-import requests
 
 
 class Gobar_ThemePlugin(plugins.SingletonPlugin):
@@ -100,9 +98,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
         if type(entity) is Package:
             if not (operation == 'changed' and entity.state == 'deleted') and entity.state != 'draft':
                 datajson_actions.enqueue_update_datajson_cache_tasks()
-                cache_clean_hook = config.get('andino.cache_clean_hook')
-                if cache_clean_hook is not None:
-                    cache_actions.clear_web_cache(cache_clean_hook)
+                cache_actions.clear_web_cache()
 
 
     def create(self, _):
@@ -111,6 +107,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
         Al llamarse esta acción, se regenera la caché del data.json
         '''
         datajson_actions.enqueue_update_datajson_cache_tasks()
+        cache_actions.clear_web_cache()
 
 
     def edit(self, _):
@@ -119,6 +116,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
         Al llamarse esta acción, se regenera la caché del data.json
         '''
         datajson_actions.enqueue_update_datajson_cache_tasks()
+        cache_actions.clear_web_cache()
 
 
     def delete(self, _):
@@ -127,6 +125,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
         Al llamarse esta acción, se regenera la caché del data.json
         '''
         datajson_actions.enqueue_update_datajson_cache_tasks()
+        cache_actions.clear_web_cache()
 
 
     def read(self, _):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -93,7 +93,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_gtm_code': gobar_helpers.get_gtm_code,
         }
 
-    def notify(self, entity, operation)
+    def notify(self, entity, operation):
 
         # Este código debería correr en una tarea async en la cola default
 

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -10,6 +10,9 @@ import ckanext.gobar_theme.helpers as gobar_helpers
 import ckanext.gobar_theme.routing as gobar_routes
 import ckanext.gobar_theme.actions as gobar_actions
 import ckanext.gobar_theme.lib.datajson_actions as datajson_actions
+import ckanext.gobar_theme.lib.cache_actions as cache_actions
+from pylons import config
+import requests
 
 
 class Gobar_ThemePlugin(plugins.SingletonPlugin):
@@ -90,10 +93,16 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_gtm_code': gobar_helpers.get_gtm_code,
         }
 
-    def notify(self, entity, operation):
+    def notify(self, entity, operation)
+
+        # Este código debería correr en una tarea async en la cola default
+
         if type(entity) is Package:
             if not (operation == 'changed' and entity.state == 'deleted') and entity.state != 'draft':
                 datajson_actions.enqueue_update_datajson_cache_tasks()
+                cache_clean_hook = config.get('andino.cache_clean_hook')
+                if cache_clean_hook is not None:
+                    cache_actions.clear_web_cache(cache_clean_hook)
 
 
     def create(self, _):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -10,7 +10,7 @@ import ckanext.gobar_theme.helpers as gobar_helpers
 import ckanext.gobar_theme.routing as gobar_routes
 import ckanext.gobar_theme.actions as gobar_actions
 import ckanext.gobar_theme.lib.datajson_actions as datajson_actions
-import ckanext.gobar_theme.lib.cache_actions as cache_actions
+from ckanext.gobar_theme.lib import cache_actions
 
 
 class Gobar_ThemePlugin(plugins.SingletonPlugin):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -92,9 +92,6 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
         }
 
     def notify(self, entity, operation):
-
-        # Este código debería correr en una tarea async en la cola default
-
         if type(entity) is Package:
             if not (operation == 'changed' and entity.state == 'deleted') and entity.state != 'draft':
                 datajson_actions.enqueue_update_datajson_cache_tasks()


### PR DESCRIPTION
Se deberá agregar, en el archivo de configuración de CKAN, el setting `andino.cache_clean_hook`, que contendrá la url a la cual se desea enviar el request para limpiar la cache.

Closes #245 