### PR TITLE
Remuevo `anchor`s que pueden potencialmente estar dentro de otro

### DIFF
--- a/ckanext/gobar_theme/templates/home/featured_content.html
+++ b/ckanext/gobar_theme/templates/home/featured_content.html
@@ -16,7 +16,7 @@
                                     <div class="featured-card">
                                         <h3>{{ h.cut_text(h.get_pkg_extra(featured_pkg, 'Responsable') or featured_pkg.author, 150) }}</h3>
                                         <h1>{{ featured_pkg.title or featured_pkg.name }}</h1>
-                                        <p>{{ h.cut_text(featured_pkg.notes, 160)|urlize }}</p>
+                                        <p>{{ h.cut_text(featured_pkg.notes, 160) }}</p>
                                     </div>
                                 </a>
                                 {% if loop.index % 2 == 1 and featured_row|length == 2%}

--- a/ckanext/gobar_theme/templates/package/snippets/dataset_resource_item.html
+++ b/ckanext/gobar_theme/templates/package/snippets/dataset_resource_item.html
@@ -14,7 +14,7 @@
 
             <h3>{{ resource.name }}</h3>
 
-            <p>{{ h.cut_text(resource.description, 140)|urlize }}</p>
+            <p>{{ h.cut_text(resource.description, 140) }}</p>
         </div>
 
         <div class="pkg-file-img" data-format="{{ format.lower() }}">

--- a/ckanext/gobar_theme/templates/package/snippets/search_item.html
+++ b/ckanext/gobar_theme/templates/package/snippets/search_item.html
@@ -11,7 +11,7 @@
                     <h3 class="dataset-title">{{ title }}</h3>
 
                     <div class="dataset-author">{{ h.cut_text(package.author, 150) }}</div>
-                    <div class="dataset-notes">{{ h.cut_text(notes, 190)|urlize }}</div>
+                    <div class="dataset-notes">{{ h.cut_text(notes, 190) }}</div>
                 </div>
                 <div class="dataset-groups-and-resources col-xs-3">
                     {%- if show_group_imgs -%}


### PR DESCRIPTION
Los `anchor` que se encuentran dentro de otro `anchor` generan que distintas vistas de CKAN se rompan.

Remuevo las llamadas a `urlize` que estén dentro de otro anchor.

closes #298