### PR TITLE
Soporte para plugin extensible

### DIFF
--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -496,3 +496,6 @@ def get_resource_icon(resource, config):
     if resource_in_config is not None:
         return resource_in_config.get('icon_url', None)
     return None
+
+def get_andino_base_page():
+    return config.get('andino.base_page', 'gobar_page.html')

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -96,6 +96,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_package_organization': gobar_helpers.get_package_organization,
             'store_object_data_excluded_from_datajson': gobar_helpers.store_object_data_excluded_from_datajson,
             'get_resource_icon': gobar_helpers.get_resource_icon,
+            'get_andino_base_page': gobar_helpers.get_andino_base_page,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/templates/about.html
+++ b/ckanext/gobar_theme/templates/about.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Acerca{% endblock %}
 

--- a/ckanext/gobar_theme/templates/about_ckan.html
+++ b/ckanext/gobar_theme/templates/about_ckan.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - CKAN{% endblock %}
 

--- a/ckanext/gobar_theme/templates/config/config_base.html
+++ b/ckanext/gobar_theme/templates/config/config_base.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 
 {% block content %}

--- a/ckanext/gobar_theme/templates/error_document_template.html
+++ b/ckanext/gobar_theme/templates/error_document_template.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - {{ gettext('Error %(error_code)s', error_code=c.code[0]) }}{% endblock %}
 

--- a/ckanext/gobar_theme/templates/group/edit.html
+++ b/ckanext/gobar_theme/templates/group/edit.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Editar grupo{% endblock %}
 

--- a/ckanext/gobar_theme/templates/group/new.html
+++ b/ckanext/gobar_theme/templates/group/new.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block content %}
     <div id="new-group-container" class="container-fluid">

--- a/ckanext/gobar_theme/templates/home/index.html
+++ b/ckanext/gobar_theme/templates/home/index.html
@@ -1,5 +1,4 @@
-{% extends "gobar_page.html" %}
-
+{% extends h.get_andino_base_page() %}
 
 {% block content %}
     <div class="home">

--- a/ckanext/gobar_theme/templates/organization/edit.html
+++ b/ckanext/gobar_theme/templates/organization/edit.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Editar organización{% endblock %}
 

--- a/ckanext/gobar_theme/templates/organization/index.html
+++ b/ckanext/gobar_theme/templates/organization/index.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Organizaciones{% endblock %}
 

--- a/ckanext/gobar_theme/templates/organization/new.html
+++ b/ckanext/gobar_theme/templates/organization/new.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Crear organización{% endblock %}
 

--- a/ckanext/gobar_theme/templates/package/drafts.html
+++ b/ckanext/gobar_theme/templates/package/drafts.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% set user = c.user_dict %}
 

--- a/ckanext/gobar_theme/templates/package/edit.html
+++ b/ckanext/gobar_theme/templates/package/edit.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Editar dataset{% endblock %}
 

--- a/ckanext/gobar_theme/templates/package/new.html
+++ b/ckanext/gobar_theme/templates/package/new.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Crear dataset{% endblock %}
 

--- a/ckanext/gobar_theme/templates/package/new_resource.html
+++ b/ckanext/gobar_theme/templates/package/new_resource.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block content %}
     <div id="new-package-container" class="container-fluid">

--- a/ckanext/gobar_theme/templates/package/read.html
+++ b/ckanext/gobar_theme/templates/package/read.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - {{ pkg.title }}{% endblock %}
 

--- a/ckanext/gobar_theme/templates/package/resource_edit_base.html
+++ b/ckanext/gobar_theme/templates/package/resource_edit_base.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% set pkg = c.pkg_dict or pkg_dict %}
 {% set logged_in = true if c.userobj else false %}

--- a/ckanext/gobar_theme/templates/package/resource_read.html
+++ b/ckanext/gobar_theme/templates/package/resource_read.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - {{ c.resource.name }}{% endblock %}
 

--- a/ckanext/gobar_theme/templates/package/resources.html
+++ b/ckanext/gobar_theme/templates/package/resources.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Recursos del dataset{% endblock %}
 

--- a/ckanext/gobar_theme/templates/package/search.html
+++ b/ckanext/gobar_theme/templates/package/search.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Datos{% endblock %}
 

--- a/ckanext/gobar_theme/templates/seccion-acerca.html
+++ b/ckanext/gobar_theme/templates/seccion-acerca.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 
 {% block page %}

--- a/ckanext/gobar_theme/templates/section_view.html
+++ b/ckanext/gobar_theme/templates/section_view.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - {{ section.title }}{% endblock %}
 

--- a/ckanext/gobar_theme/templates/user/expired_key.html
+++ b/ckanext/gobar_theme/templates/user/expired_key.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - {{ gettext('Error %(error_code)s', error_code=c.code[0]) }}{% endblock %}
 

--- a/ckanext/gobar_theme/templates/user/login.html
+++ b/ckanext/gobar_theme/templates/user/login.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 {% block subtitle %} - Ingresar{% endblock %}
 

--- a/ckanext/gobar_theme/templates/user/user_config_base.html
+++ b/ckanext/gobar_theme/templates/user/user_config_base.html
@@ -1,4 +1,4 @@
-{% extends "gobar_page.html" %}
+{% extends h.get_andino_base_page() %}
 
 
 {% block content %}


### PR DESCRIPTION
## Rationale

Para poder overridear templates desde un plugin que provee de extensibilidad a Andino (por ejemplo, agregar elementos al nav principal) es necesario soportar la posibilidad de definir cual es el template base.

Esta funcionalidad se otorga en este PR, permitiendo definir un atributo de configuración denominado `andino.base_page` que define cual es el template base.

Un plugin extensible podría proveer de este template base y modificar las secciones deseadas.

## Cómo probar el PR

1. Clonar datosgobar/portal-andino
1. Dentro de la raíz de datosgobar/portal-andino, levantar andino usando `./dev.sh build && ./dev.sh up && ./dev.sh setup`.
1. Ingresar al contenedor portal usando `./dev.sh exec bash`
1. Dentro del contenedor cambiar a la rama `portal-andino-151-soporte-para-plugin-extensible`: `cd /usr/lib/ckan/default/src/ckanext-gobar-theme/ && git fetch && git checkout portal-andino-151-soporte-para-plugin-extensible`
1. Instalar el plugin localmente: `/usr/lib/ckan/default/bin/pip install -e .`
1. Reiniciar apache: `apachectl restart`
1. Verificar que nada se rompió :smile: 

### Opcional

1. Clonar el plugin `ckanext-andinotemplate`: `pip install -e git+https://github.com/devartis/ckanext-andinotemplate.git#egg=ckanext-andinotemplate`.
1. Editar `/etc/ckan/default/production.ini` y agregar `andinotemplate` a la lista de `ckan.plugins` y agregar el setting `andino.base_page = andino_custom_base_page.html`
1. Reiniciar apache: `apachectl restart`
1. Verificar que hay un elemento en el menú llamado "Andino".

Este PR no cierra por completo el issue datosgobar/portal-andino#151 ya que falta algo de documentación y mostrar un ejemplo de cómo agregar una página estática custom.