### PR TITLE
Soluciono problema de renderización de `field`

### DIFF
--- a/ckanext/gobar_theme/lib/datajson_actions.py
+++ b/ckanext/gobar_theme/lib/datajson_actions.py
@@ -288,12 +288,16 @@ def get_datasets_with_resources(packages):
         try:
             for index, resource in enumerate(packages[i]['resources']):
                 try:
-                    fixed_attrDesc = json.loads(resource['attributesDescription'])
-                    packages[i]['resources'][index]['attributesDescription'] = fixed_attrDesc
+                    attributes_description_as_dict = json.loads(resource.get('attributesDescription', '[]'))
+                    packages[i]['resources'][index]['attributesDescription'] = attributes_description_as_dict
                 except ValueError:
+                    attributes_description_as_dict = []
                     logger.error('Fallo render de \'attributesDescription\'.')
+                except KeyError as e:
+                    logger.error(u'Error transformando attributesDescription de %s', resource)
+                    raise e
         except KeyError:
-            pass
+            logger.error(u"Fallo durante la transformación de 'attributesDescription' del package %s.", packages[i].get('id'))
         ckan_host = ''
         try:
             ckan_host = re.match(


### PR DESCRIPTION
Contemplo el caso en que alguno de los recursos de dataset no tuviera `field` / `attributesDescription`, que causaba que todos los recursos siguientes se quedaran con el valor default de .

closes #294