### PR TITLE
Integracion con TS explorer

### DIFF
--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -268,6 +268,19 @@ class GobArConfigController(base.BaseController):
             self._set_config(config_dict)
         return base.render('config/config_13_apis.html')
 
+    def edit_series(self):
+        self._authorize()
+        if request.method == 'POST':
+            params = parse_params(request.POST)
+            config_dict = self._read_config()
+            config_dict['series_tiempo_ar_explorer'] = {
+                'catalog_id': params['catalog_id'].strip(),
+                "featured": params['featured'].strip(),
+                'enable': 'enable' in params
+            }
+            self._set_config(config_dict)
+        return base.render('config/config_14_series.html')
+
     def edit_greetings(self):
         self._authorize()
         if request.method == 'POST':

--- a/ckanext/gobar_theme/routing.py
+++ b/ckanext/gobar_theme/routing.py
@@ -219,6 +219,7 @@ class GobArRouter:
             m.connect('/configurar/metadata/tw', action='edit_metadata_tw')
             m.connect('/configurar/metadata/portal', action='edit_metadata_portal')
             m.connect('/configurar/mensaje_de_bienvenida', action='edit_greetings')
+            m.connect('/configurar/series', action='edit_series')
 
         self.redirect(
             ('/configurar', '/configurar/titulo'),

--- a/ckanext/gobar_theme/templates/config/config_14_series.html
+++ b/ckanext/gobar_theme/templates/config/config_14_series.html
@@ -1,0 +1,28 @@
+{% extends "config/config_base.html" %}
+{% block config %}
+<h1>Series</h1>
+
+<form method="post" action="" data-module="basic-form">
+    <label class="with-bottom-margin checkbox-label">
+        <input type="checkbox"
+               name="enable" {{ 'checked="checked"' if h.get_theme_config('series_tiempo_ar_explorer.enable') else ''
+        }}>
+        ¿Querés que esta sección se vea en tu portal?
+    </label>
+
+    <h2>¿A qué catálogo querés limitar las búsquedas?</h2>
+    <input type="text"
+           name="catalog_id" value="{{ h.get_theme_config('series_tiempo_ar_explorer.catalog_id') or '' }}">
+
+    <h2>
+        ¿Querés destacar algunas series?
+
+    </h2>
+    <input type="text"
+           name="featured" value="{{ h.get_theme_config('series_tiempo_ar_explorer.featured') or '' }}">
+
+    <div class="submit-container">
+        <button class="submit-button" type="submit" name="save">GUARDAR</button>
+    </div>
+</form>
+{% endblock -%}

--- a/ckanext/gobar_theme/templates/config/navbar.html
+++ b/ckanext/gobar_theme/templates/config/navbar.html
@@ -46,6 +46,10 @@
            class="section-link {{ 'active' if c.action == 'edit_apis' else '' }}">
             APIs
         </a>
+        <a href="{{ h.url_for(controller='ckanext.gobar_theme.config_controller:GobArConfigController', action='edit_series') }}"
+           class="section-link {{ 'active' if c.action == 'edit_series' else '' }}">
+            Series
+        </a>
     </div>
 
     <h2>Metadatos</h2>

--- a/ckanext/gobar_theme/templates/header.html
+++ b/ckanext/gobar_theme/templates/header.html
@@ -26,6 +26,13 @@
                         </a>
                     </div>
                     <hr>
+                    {% if h.get_theme_config('series_tiempo_ar_explorer.enable') %}
+                        <div class="navbar-link">
+                            <a href="{{ h.url_for(controller='ckanext.seriestiempoarlanding.controller:TSArController', action='series_tiempo') }}">
+                                Series
+                            </a>
+                        </div>
+                    {% endif %}
                     {% if h.get_theme_config('organization.show-organizations') %}
                         <div class="navbar-link">
                             <a href="{{ h.url_for(controller='organization', action='index') }}">
@@ -111,6 +118,9 @@
                 {%- if c.action != 'login' -%}
                     <a class="header-link" href="{{ h.url_for(controller='package', action='search') }}">Datasets</a>
 
+                    {%- if h.get_theme_config('series_tiempo_ar_explorer.enable') -%}
+                        <a class="header-link" href="{{ h.url_for(controller='ckanext.seriestiempoarlanding.controller:TSArController', action='series_tiempo') }}">Series</a>
+                    {%- endif -%}
                     {%- if h.get_theme_config('organization.show-organizations') -%}
                         <a class="header-link" href="{{ h.url_for(controller='organization', action='index') }}">Organizaciones</a>
                     {%- endif -%}

--- a/ckanext/gobar_theme/templates/header.html
+++ b/ckanext/gobar_theme/templates/header.html
@@ -119,7 +119,7 @@
                     <a class="header-link" href="{{ h.url_for(controller='package', action='search') }}">Datasets</a>
 
                     {%- if h.get_theme_config('series_tiempo_ar_explorer.enable') -%}
-                        <a class="header-link" href="{{ h.url_for(controller='ckanext.seriestiempoarlanding.controller:TSArController', action='series_tiempo') }}">Series</a>
+                        <a class="header-link" href="{{ h.url_for(controller='ckanext.seriestiempoarexplorer.controller:TSArController', action='series_tiempo') }}">Series</a>
                     {%- endif -%}
                     {%- if h.get_theme_config('organization.show-organizations') -%}
                         <a class="header-link" href="{{ h.url_for(controller='organization', action='index') }}">Organizaciones</a>


### PR DESCRIPTION
Agrego integracion con el explorardor de TS.

Para probarlo:

- Ir a portal andino,  levantarlo en modo desarrollo.
- Crear un directorio `wrks/` y clonar dentro este branch y [esta integracion](https://github.com/datosgobar/ckanext-seriestiempoarexplorer/).
- Entrar al contenedor de andino, ir a `/dev-app/wrks/`
- En cada directorio, correr `python setup.py develop`
- ir al `production.ini` y agregar `seriestiempoarexplorer` a los plugins
- correr `apachectl restart`
- Deberiamos poder ir a `http://localhost/configurar/series` y ver la configuracion de Series