### PR TITLE
Fix función de guardado de información excluida del datajson

### DIFF
--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -484,7 +484,8 @@ def store_object_data_excluded_from_datajson(object_dict_name, data_dict):
         config[object_dict_name] = config_item
 
         GobArConfigController.set_theme_config(config)
-    return config[object_dict_name][data_dict.get('id', data_dict_id)]
+        return config[object_dict_name][data_dict.get('id', data_dict_id)]
+    return None
 
 
 def get_resource_icon(resource, config):


### PR DESCRIPTION
Closes #314 
La función `store_object_data_excluded_from_datajson` tiraba error cuando se federaba un dataset porque buscaba los recursos del mismo aún si no se había agregado un ícono para ellos y no los encontraba buscándolos por id.

### Cómo probar el PR

* Federar un dataset
* Entrar al formulario de edición de uno de sus recursos
* Darles un ícono y guardar
* - Opcional: asegurarse de que la url de ícono aparezca en el archivo `settings.json`
* Volver a federar ese mismo dataset de nuevo, específicamente con los mismos parámetros de antes
* Chequear la consola y verificar que no haya un mensaje de error similar al mostrado en el issue #314 