### PR TITLE
Los usuarios colaboradores no tienen permisos para administrar las co…

### DIFF
--- a/ckanext/gobar_theme/lib/datajson_actions.py
+++ b/ckanext/gobar_theme/lib/datajson_actions.py
@@ -44,8 +44,11 @@ def get_data_json_contents():
 
 def enqueue_update_datajson_cache_tasks():
     # Las funciones que usamos de RQ requieren que se les envíe el context para evitar problemas de autorización
-    context = {'model': model, 'session': model.Session, 'user': c.user}
-    delete.job_clear(context, {'queues': [ANDINO_DATAJSON_QUEUE]})
+    try:
+        context = {'model': model, 'session': model.Session, 'user': c.user}
+        delete.job_clear(context, {'queues': [ANDINO_DATAJSON_QUEUE]})
+    except logic.NotAuthorized:
+        logger.info(u'Usuario %s no tiene permisos para administrar colas de trabajo. No es posible limpiar las colas previo actualización de data.json', c.user)
     jobs.enqueue(update_datajson_cache, queue=ANDINO_DATAJSON_QUEUE)
     jobs.enqueue(update_catalog, queue=ANDINO_DATAJSON_QUEUE)
 


### PR DESCRIPTION
…las de trabajo de tareas asincrónicas de CKAN.

Es por esto que verificamos que no se lance una excepción al eliminar las tareas y luego encolamos la tarea de actualización.

closes #328