### PR TITLE
Corrección de error en el chequeo

### DIFF
--- a/ckanext/gobar_theme/templates/datajson.html
+++ b/ckanext/gobar_theme/templates/datajson.html
@@ -97,11 +97,11 @@
                         {%- if distrib.field|length > 0 %}
                              "field":       {{ h.jsondump(distrib.field) }},
                         {%- endif %}
-                        {%- if distrib.field|length > 0 %}
-                             "accessURL":       {{ h.jsondump(distrib.accessURL) }},
+                        {%- if distrib.accessURL|length > 0 %}
+                             "accessURL": {{ h.jsondump(distrib.accessURL) }},
                         {%- endif %}
-                            {%- if distrib.field|length > 0 %}
-                             "downloadURL":       {{ h.jsondump(distrib.downloadURL) }},
+                        {%- if distrib.downloadURL|length > 0 %}
+                             "downloadURL": {{ h.jsondump(distrib.downloadURL) }},
                         {%- endif %}
                             "identifier":       "{{ distrib.identifier }}"
                         } {% if loop.index < dataset.distribution|length %},{% endif %}


### PR DESCRIPTION
El chequeo debe ser por el mismo campo que se quiere renderizar.

Incorrectamente (error de copy/paste) se estaba chequeando otro campo.

closes #331