### PR TITLE
Modificar accessURL en formulario de recursos

### DIFF
--- a/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
+++ b/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
@@ -1,11 +1,13 @@
 $(function () {
 
     $(document).on('click', '.url-button', function () {
-        if ($('#distribution-type').val() !== 'api'){
-            $('#form-file-name').show();
-            $('#field-file-name').show();
+        if($(this).siblings("#resource-upload-url").length > 0) {  // Aseguro que se esté clickeando el botón de URL
+            if ($('#distribution-type').val() !== 'api'){
+                $('#form-file-name').show();
+                $('#field-file-name').show();
+            }
+            $('option.distribution-type-option[value="file.upload"]').val('file');
         }
-        $('option.distribution-type-option[value="file.upload"]').val('file');
     });
 
     $(document).on('click', '.file-upload-label', function () {

--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -10361,3 +10361,15 @@ div.about-template-buttons > button {
 div.about-template-icons {
   font-family: inherit;
 }
+
+div#form-accessURL > div > div.control-group.control-full {
+  margin-bottom: 5px !important;
+}
+
+div#form-accessURL {
+  margin-bottom: 25px;
+}
+
+label[for="accessURL-upload-url"] {
+  display: none !important;
+}

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form.html
@@ -108,7 +108,7 @@
 
     <div id="form-accessURL">
         {{ form.image_upload(data, errors, field_url='accessURL', field_upload='accessURL_field', field_clear='clear_accessURL',
-         is_upload_enabled=h.uploads_enabled(), is_url=data.url, is_upload=is_upload,
+         is_upload_enabled=h.uploads_enabled(), is_url=data.accessURL, is_upload=False,
          upload_label="URL de acceso", url_label="URL de acceso", id_prefix='accessURL', placeholder='http://datos.gob.ar/ejemplo.ext') }}
         <p class="empty-accessURL-description">En el caso de que no quieras especificar una URL de acceso, se utilizará una default.</p>
     </div>

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form.html
@@ -101,9 +101,17 @@
                 {{ form.input('format', id='field-format', label=_('Format'), placeholder='Ej.: CSV, XML o JSON.', value=data.format, error=errors.format, classes=['control-medium'], attrs=format_attrs) }}
             </div>
         {% endblock %}
+
     {% endblock basic_fields %}
 
     {% snippet 'package/snippets/resource_form_license.html', data=data %}
+
+    <div id="form-accessURL">
+        {{ form.image_upload(data, errors, field_url='accessURL', field_upload='accessURL_field', field_clear='clear_accessURL',
+         is_upload_enabled=h.uploads_enabled(), is_url=data.url, is_upload=is_upload,
+         upload_label="URL de acceso", url_label="URL de acceso", id_prefix='accessURL', placeholder='http://datos.gob.ar/ejemplo.ext') }}
+        <p class="empty-accessURL-description">En el caso de que no quieras especificar una URL de acceso, al guardar el recurso se generará una por default.</p>
+    </div>
 
     {% snippet 'package/snippets/resource_form_attributes.html', data=data %}
 

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form.html
@@ -110,7 +110,7 @@
         {{ form.image_upload(data, errors, field_url='accessURL', field_upload='accessURL_field', field_clear='clear_accessURL',
          is_upload_enabled=h.uploads_enabled(), is_url=data.url, is_upload=is_upload,
          upload_label="URL de acceso", url_label="URL de acceso", id_prefix='accessURL', placeholder='http://datos.gob.ar/ejemplo.ext') }}
-        <p class="empty-accessURL-description">En el caso de que no quieras especificar una URL de acceso, al guardar el recurso se generará una por default.</p>
+        <p class="empty-accessURL-description">En el caso de que no quieras especificar una URL de acceso, se utilizará una default.</p>
     </div>
 
     {% snippet 'package/snippets/resource_form_attributes.html', data=data %}


### PR DESCRIPTION
Se agregó una sección para la URL de acceso (accessURL) en el formulario de creación/modificación de recursos.

El campo es opcional, y el usuario podrá modificarlo haciendo click en el botón "ENLACE" dentro la sección mencionada.

Closes #297 