### PR TITLE
Fix de la sección Acerca del header al navegar en mobile

### DIFF
--- a/ckanext/gobar_theme/templates/header.html
+++ b/ckanext/gobar_theme/templates/header.html
@@ -61,7 +61,7 @@
                                 {% if header_sections|length > 0 %}
                                     {% for header_section in header_sections %}
                                         <div class="navbar-link">
-                                            <a href="{{ h.url('gobar_our_site') }}">
+                                            <a href="{{ h.url('section', title=header_section.title) }}">
                                                 {{ header_section.title }}
                                             </a>
                                         </div>


### PR DESCRIPTION
Anteriormente, la versión mobile de la sección Acerca (personalizada) del header redirigía a `/gobar_our_site`.

Closes #338 