### PR TITLE
Cambio lógica para el manejo del campo 'Nombre del archivo'

### DIFF
--- a/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
+++ b/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
@@ -12,8 +12,14 @@ $(function () {
 
     $(document).on('click', '.file-upload-label', function () {
         $('input#' + $(event.target).parent().attr('for')).click();  // Disparo el click en el input[type=file]
-        $('#form-file-name').hide();
         $('option.distribution-type-option[value="file"]').val('file.upload');
+    });
+
+    $(document).on('click', 'a.btn-remove-url', function () {
+        if ($(this).siblings("input#resource-upload-url").length > 0) {  // Aseguro que se esté cerrando el input de URL
+            $('#form-file-name').hide();
+            $('input#field-file-name').val('');
+        }
     });
 
 });


### PR DESCRIPTION
El campo desaparecía cuando se hacía click en el botón `SUBIR` dentro del campo URL.
Se cambió el script para que esto ocurra al cerrar el input de ese campo.

Para probarlo:
* Ir al formulario de creación/edición de recursos
* Hacer click en `ENLACE`
* Escribir un nombre de archivo
* Cerrar el input de `URL`
* Volver a clickear `ENLACE` -> no debería haber un nombre de archivo

Closes #318 