### PR TITLE
Performance en la pantalla de organizaciones

### DIFF
--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -99,6 +99,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_resource_icon': gobar_helpers.get_resource_icon,
             'get_andino_base_page': gobar_helpers.get_andino_base_page,
             'is_plugin_present': is_plugin_present,
+            'organizations_basic_info': gobar_helpers.organizations_basic_info,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/templates/organization/index.html
+++ b/ckanext/gobar_theme/templates/organization/index.html
@@ -29,7 +29,7 @@
                         {% set top_organization = organization.depth == 0 %}
 
                         {% if top_organization and organization.total_package_count > 0 %}
-                            <a class="repio" href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
+                            <a href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
                         {% endif %}
 
                         <div class="organization-branch">

--- a/ckanext/gobar_theme/templates/organization/index.html
+++ b/ckanext/gobar_theme/templates/organization/index.html
@@ -21,15 +21,15 @@
                         <span class="count-title">Datasets totales</span>
                     </div>
 
-                    {% set organizations_tree = h.organization_tree() %}
+                    {% set organizations_tree = h.organizations_basic_info() %}
                     {% set dataset_url = h.url_for(controller='package', action='search') %}
 
                     {% for organization in organizations_tree recursive %}
 
                         {% set top_organization = organization.depth == 0 %}
 
-                        {% if top_organization and organization.display_count > 0 %}
-                            <a href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
+                        {% if top_organization and organization.total_package_count > 0 %}
+                            <a class="repio" href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
                         {% endif %}
 
                         <div class="organization-branch">
@@ -40,10 +40,10 @@
                                     {%- snippet "svg/chevron_right.svg" -%}
                                 {%- endif -%}
 
-                                {%- if organization.package_count > 0 -%}
-                                        {{ organization.display_name }} ({{ organization.package_count }})
+                                {%- if organization.own_package_count > 0 -%}
+                                        {{ organization.name }} ({{ organization.own_package_count }})
                                 {%- else -%}
-                                    {{ organization.display_name }}
+                                    {{ organization.name }}
                                 {%- endif -%}
 
                                 {%- if c.userobj and c.userobj.sysadmin -%}
@@ -56,7 +56,7 @@
 
                                 {%- if top_organization -%}
                                     <span class="organization-count">
-                                        {{ organization.display_count }}
+                                        {{ organization.total_package_count }}
                                     </span>
                                 {%- endif -%}
 
@@ -67,7 +67,7 @@
                             {% endif %}
                         </div>
 
-                        {% if top_organization and organization.display_count > 0 %}
+                        {% if top_organization and organization.total_package_count > 0 %}
                             </a>
                         {% endif %}
 


### PR DESCRIPTION
Se creó un helper nuevo (`organizations_basic_info`) para reemplazar a la función `organization_tree`.
Este helper consigue lo mínimo y necesario para la visualización de las organizaciones, sin lo extra que busca/calcula CKAN, con la finalidad de mejorar la performance al ingresar a `/organizaciones`.

Closes #325 