### PR TITLE
Las suborganizaciones tiene su propio anchor

### DIFF
--- a/ckanext/gobar_theme/templates/organization/index.html
+++ b/ckanext/gobar_theme/templates/organization/index.html
@@ -28,20 +28,18 @@
 
                         {% set top_organization = organization.depth == 0 %}
 
-                        {% if top_organization and organization.total_package_count > 0 %}
-                            <a href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
-                        {% endif %}
 
                         <div class="organization-branch">
-
 
                             <div class="organization-name {{ 'top-organization' if top_organization else '' }}">
                                 {%- if top_organization -%}
                                     {%- snippet "svg/chevron_right.svg" -%}
                                 {%- endif -%}
 
-                                {%- if organization.own_package_count > 0 -%}
-                                        {{ organization.name }} ({{ organization.own_package_count }})
+                                {%- if organization.total_package_count > 0 -%}
+                                    <a href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
+                                        {{ organization.name }} {{ ('(%d)' % organization.own_package_count) if organization.own_package_count }}
+                                    </a>
                                 {%- else -%}
                                     {{ organization.name }}
                                 {%- endif -%}
@@ -65,11 +63,9 @@
                             {% if organization.children %}
                                 {{ loop(organization.children) }}
                             {% endif %}
+
                         </div>
 
-                        {% if top_organization and organization.total_package_count > 0 %}
-                            </a>
-                        {% endif %}
 
                         {% if top_organization %}
                             <hr>


### PR DESCRIPTION
Las organizaciones raíz siempre tuvieron un anchor que incluía a todas sus suborganizaciones; es decir, clickear una suborganización solamente servía para filtrar datasets utilizando como filtro a la organización raíz.
Además, después de los cambios para el issue #325, específicamente en el caso de que se haya iniciado sesión, las suborganizaciones dejaban de ser parte del anchor y se volvían texto puro.

Se arregló este inconveniente haciendo que cada organización tenga su propio anchor, el cual no contendrá a ninguna suborganización.

Closes #344 