### PR TITLE
Fix al mostrar el título de una organización con datasets

### DIFF
--- a/ckanext/gobar_theme/templates/organization/index.html
+++ b/ckanext/gobar_theme/templates/organization/index.html
@@ -38,7 +38,7 @@
 
                                 {%- if organization.total_package_count > 0 -%}
                                     <a href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
-                                        {{ organization.name }} {{ ('(%d)' % organization.own_package_count) if organization.own_package_count }}
+                                        {{ organization.title }} {{ ('(%d)' % organization.own_package_count) if organization.own_package_count }}
                                     </a>
 
                                 {%- else -%}


### PR DESCRIPTION
Anteriormente, se utilizaba el campo `name` de una organización que tenía datasets para mostrarla en la pantalla de organizaciones.
Ahora, se cambió el template para que se utilize el campo `title`.

Closes #353 