### PR TITLE
Consistencia en espacio vacío detrás del título de las organizaciones

### DIFF
--- a/ckanext/gobar_theme/templates/organization/index.html
+++ b/ckanext/gobar_theme/templates/organization/index.html
@@ -37,13 +37,9 @@
                                 {%- endif -%}
 
                                 {%- if organization.total_package_count > 0 -%}
-                                    <a href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">
-                                        {{ organization.name }} {{ ('(%d)' % organization.own_package_count) if organization.own_package_count }}
-                                    </a>
+                                    <a href="{{ h.add_url_param(new_params={'organization': organization.name}, alternative_url=dataset_url) }}">{{ organization.name }} {{ ('(%d)' % organization.own_package_count) if organization.own_package_count }}</a>
 
-                                {%- else -%}
-                                    {{ organization.title }}
-                                {%- endif -%}
+                                {%- else -%}{{ organization.title }}{%- endif -%}
 
                                 {%- if c.userobj and c.userobj.sysadmin -%}
                                     <a href="{{ h.url_for(controller='organization', action='edit', id=organization.name) }}">


### PR DESCRIPTION
Anteriormente, algunos títulos de organizaciones en la página de las mismas tenían un espacio vacío detrás que no coincidía con el de los demás.
Se eliminó el whitespace que se creaba al renderear el template para que estén todos los títulos alineados.
Closes #354.