### PR TITLE
Uso del valor default para la URL de la API de series en production.ini

### DIFF
--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -272,6 +272,7 @@ class GobArConfigController(base.BaseController):
         return base.render('config/config_13_apis.html')
 
     def edit_series(self):
+        from ckanext.gobar_theme.helpers import get_default_series_api_url
         plugin_or_404(TS_EXPLORER_PLUGIN)
         self._authorize()
         if request.method == 'POST':
@@ -280,7 +281,7 @@ class GobArConfigController(base.BaseController):
             config_dict['series_tiempo_ar_explorer'] = {
                 'featured': params['featured'].strip(),
                 'enable': 'enable' in params,
-                'series-api-uri': params['series-api-uri'] or ckan_config.get('seriestiempoarexplorer.default_series_api_uri')
+                'series-api-uri': params['series-api-uri'] or get_default_series_api_url()
             }
             self._set_config(config_dict)
         return base.render('config/config_14_series.html')

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -547,5 +547,10 @@ def get_resource_icon(resource, config):
         return resource_in_config.get('icon_url', None)
     return None
 
+
 def get_andino_base_page():
     return config.get('andino.base_page', 'gobar_page.html')
+
+
+def get_default_series_api_url():
+    return config.get('seriestiempoarexplorer.default_series_api_uri', '')

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -100,6 +100,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_andino_base_page': gobar_helpers.get_andino_base_page,
             'is_plugin_present': is_plugin_present,
             'organizations_basic_info': gobar_helpers.organizations_basic_info,
+            'get_default_series_api_url': gobar_helpers.get_default_series_api_url,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/templates/config/config_14_series.html
+++ b/ckanext/gobar_theme/templates/config/config_14_series.html
@@ -18,7 +18,7 @@
            name="featured" value="{{ h.get_theme_config('series_tiempo_ar_explorer.featured') or '' }}">
 
     <h2>URI de la API de Series</h2>
-    <input type="text" name="series-api-uri" value="{{ h.get_theme_config('series_tiempo_ar_explorer.series-api-uri') or '' }}">
+    <input type="text" name="series-api-uri" value="{{ h.get_theme_config('series_tiempo_ar_explorer.series-api-uri') or h.get_default_series_api_url() }}">
 
     <div class="submit-container">
         <button class="submit-button" type="submit" name="save">GUARDAR</button>


### PR DESCRIPTION
El valor de la URL para la API de series busca el default en el archivo de configuración en caso de estar vacío