### PR TITLE
Parametrizar id de Google Tag y Analytics por UI

### DIFF
--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -4,13 +4,15 @@ import os
 import re
 import urlparse
 
+from ckan import plugins as p
 import ckan.lib.base as base
 import ckan.lib.helpers as h
 import ckan.logic as logic
+from ckan.logic import get_action
 import ckan.model as model
 import moment
 import redis
-from ckan.common import request, c
+from ckan.common import request, c, config
 from pylons import config as ckan_config
 from ckanext.gobar_theme.lib import cache_actions
 
@@ -312,11 +314,22 @@ class GobArConfigController(base.BaseController):
         self._authorize()
         if request.method == 'POST':
             params = parse_params(request.POST)
+            google_analytics_id = params['id'].strip()
             config_dict = self._read_config()
             config_dict['google_analytics'] = {
-                'id': params['id'].strip()
+                'id': google_analytics_id
             }
             self._set_config(config_dict)
+            # Utilizamos la funcion config_option_update que nos provee CKAN para actualizar en runtime el id de Google
+            # Analytics en la configuración
+            get_action('config_option_update')({}, {
+               'googleanalytics.id': google_analytics_id
+            })
+
+            # Notificamos a todos los plugins de la nueva configuración
+            for plugin in p.PluginImplementations(p.IConfigurable):
+                plugin.configure(config)
+
         return base.render('config/config_17_google_analytics.html')
 
     def edit_greetings(self):

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -8,6 +8,7 @@ from ckan import plugins as p
 import ckan.lib.base as base
 import ckan.lib.helpers as h
 import ckan.logic as logic
+from ckan.lib.redis import is_redis_available
 from ckan.logic import get_action
 import ckan.model as model
 import moment
@@ -362,13 +363,16 @@ class GobArConfigController(base.BaseController):
             andino_config = cls._redis_cli().get('andino-config')
             gobar_config = json.loads(andino_config)
         except Exception:
-            with open(GobArConfigController.CONFIG_PATH) as json_data:
-                try:
+            try:
+                with open(GobArConfigController.CONFIG_PATH) as json_data:
                     gobar_config = json.load(json_data)
-                except Exception:
-                    gobar_config = {}
+            except Exception:
+                gobar_config = {}
+            try:
+                is_redis_available()
                 cls._redis_cli().set('andino-config', json.dumps(gobar_config))
-
+            except Exception:
+                print("Redis no se encuentra disponible!")
         return gobar_config
 
     @classmethod

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -314,6 +314,7 @@ class GobArConfigController(base.BaseController):
         return base.render('config/config_16_google_tag_manager.html')
 
     def edit_google_analytics(self):
+        from ckanext.gobar_theme.helpers import search_for_value_in_config_file
         self._authorize()
         if request.method == 'POST':
             params = parse_params(request.POST)
@@ -326,7 +327,7 @@ class GobArConfigController(base.BaseController):
             # Utilizamos la funcion config_option_update que nos provee CKAN para actualizar en runtime el id de Google
             # Analytics en la configuración
             get_action('config_option_update')({}, {
-               'googleanalytics.id': google_analytics_id
+               'googleanalytics.id': google_analytics_id or search_for_value_in_config_file('googleanalytics.id')
             })
 
             # Notificamos a todos los plugins de la nueva configuración

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import logging
 import urlparse
 
 from ckan import plugins as p
@@ -23,6 +24,7 @@ parse_params = logic.parse_params
 abort = base.abort
 check_access = logic.check_access
 NotAuthorized = logic.NotAuthorized
+logger = logging.getLogger(__name__)
 
 
 class GobArConfigController(base.BaseController):
@@ -372,7 +374,7 @@ class GobArConfigController(base.BaseController):
                 is_redis_available()
                 cls._redis_cli().set('andino-config', json.dumps(gobar_config))
             except Exception:
-                print("Redis no se encuentra disponible!")
+                logger.error("Redis no se encuentra disponible!")
         return gobar_config
 
     @classmethod

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -308,6 +308,17 @@ class GobArConfigController(base.BaseController):
             self._set_config(config_dict)
         return base.render('config/config_16_google_tag_manager.html')
 
+    def edit_google_analytics(self):
+        self._authorize()
+        if request.method == 'POST':
+            params = parse_params(request.POST)
+            config_dict = self._read_config()
+            config_dict['google_analytics'] = {
+                'id': params['id'].strip()
+            }
+            self._set_config(config_dict)
+        return base.render('config/config_17_google_analytics.html')
+
     def edit_greetings(self):
         self._authorize()
         if request.method == 'POST':

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -297,6 +297,17 @@ class GobArConfigController(base.BaseController):
             self._set_config(config_dict)
         return base.render('config/config_15_google_dataset_search.html')
 
+    def edit_google_tag_manager(self):
+        self._authorize()
+        if request.method == 'POST':
+            params = parse_params(request.POST)
+            config_dict = self._read_config()
+            config_dict['google_tag_manager'] = {
+                'container-id': params['container-id'].strip()
+            }
+            self._set_config(config_dict)
+        return base.render('config/config_16_google_tag_manager.html')
+
     def edit_greetings(self):
         self._authorize()
         if request.method == 'POST':

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -5,6 +5,7 @@ import ckan.lib.helpers as ckan_helpers
 import ckan.lib.search as search
 import ckan.logic as logic
 import moment
+import subprocess
 from ckan.common import request, c, g, _
 import ckan.lib.formatters as formatters
 import json
@@ -560,3 +561,10 @@ def get_default_series_api_url():
 def get_google_analytics_id():
     return get_theme_config('google_analytics.id') or \
            config.get('googleanalytics.id', '')
+
+
+def search_for_value_in_config_file(field):
+    value = subprocess.check_output(
+        'grep -E "^{}[[:space:]]*=[[:space:]]*" '
+        '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(field), shell=True).strip()
+    return value.replace(field, '')[1:]

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -555,3 +555,8 @@ def get_andino_base_page():
 
 def get_default_series_api_url():
     return config.get('seriestiempoarexplorer.default_series_api_uri', '')
+
+
+def get_google_analytics_id():
+    return get_theme_config('google_analytics.id') or \
+           config.get('googleanalytics.id', '')

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -564,7 +564,11 @@ def get_google_analytics_id():
 
 
 def search_for_value_in_config_file(field):
-    value = subprocess.check_output(
-        'grep -E "^{}[[:space:]]*=[[:space:]]*" '
-        '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(field), shell=True).strip()
-    return value.replace(field, '')[1:]
+    # Solamente queremos utilizar el valor default cuando no existe uno ingresado por el usuario.
+    try:
+        value = subprocess.check_output(
+            'grep -E "^{}[[:space:]]*=[[:space:]]*" '
+            '/etc/ckan/default/production.ini | tr -d [[:space:]]'.format(field), shell=True).strip()
+        return value.replace(field, '')[1:]
+    except:
+        return ''

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -497,7 +497,8 @@ def get_default_background_configuration():
 
 
 def get_gtm_code():
-    return config.get('ckan.google_tag_manager.gtm_container_id', None)
+    return get_theme_config('google_tag_manager.container-id') or \
+           config.get('ckan.google_tag_manager.gtm_container_id', '')
 
 
 def get_current_url_for_resource(package_id, resource_id):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -102,6 +102,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'is_plugin_present': is_plugin_present,
             'organizations_basic_info': gobar_helpers.organizations_basic_info,
             'get_default_series_api_url': gobar_helpers.get_default_series_api_url,
+            'get_google_analytics_id': gobar_helpers.get_google_analytics_id,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -24,6 +24,8 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
     implements(plugins.IUploader)
     implements(interfaces.IDomainObjectModification)
     implements(interfaces.IGroupController)
+    implements(interfaces.IGroupController)
+    implements(interfaces.IConfigurable)
 
     def get_resource_uploader(self, data_dict):
         return GobArThemeResourceUploader(data_dict)
@@ -42,6 +44,10 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'organization_delete': gobar_actions.organization_delete_and_purge,
             'gobar_status_show': gobar_actions.gobar_status_show}
 
+    def configure(self, config):
+        config['googleanalytics.id'] = gobar_helpers.get_google_analytics_id()
+
+
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_template_directory(config_, '/var/lib/ckan/theme_config/templates')
@@ -49,6 +55,15 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
         toolkit.add_resource('styles/css', 'gobar_css')
         toolkit.add_resource('js', 'gobar_js')
         toolkit.add_resource('recline', 'gobar_data_preview')
+
+
+    def update_config_schema(self, schema):
+
+        schema.update({
+            'googleanalytics.id': [unicode, ],
+        })
+
+        return schema
 
     def before_map(self, routing_map):
         gobar_router = gobar_routes.GobArRouter(routing_map)

--- a/ckanext/gobar_theme/routing.py
+++ b/ckanext/gobar_theme/routing.py
@@ -219,6 +219,7 @@ class GobArRouter:
             m.connect('/configurar/metadata/tw', action='edit_metadata_tw')
             m.connect('/configurar/metadata/portal', action='edit_metadata_portal')
             m.connect('/configurar/google_dataset_search', action='edit_google_dataset_search')
+            m.connect('/configurar/google_tag_manager', action='edit_google_tag_manager')
             m.connect('/configurar/mensaje_de_bienvenida', action='edit_greetings')
             m.connect('/configurar/series', action='edit_series')
 

--- a/ckanext/gobar_theme/routing.py
+++ b/ckanext/gobar_theme/routing.py
@@ -220,6 +220,7 @@ class GobArRouter:
             m.connect('/configurar/metadata/portal', action='edit_metadata_portal')
             m.connect('/configurar/google_dataset_search', action='edit_google_dataset_search')
             m.connect('/configurar/google_tag_manager', action='edit_google_tag_manager')
+            m.connect('/configurar/google_analytics', action='edit_google_analytics')
             m.connect('/configurar/mensaje_de_bienvenida', action='edit_greetings')
             m.connect('/configurar/series', action='edit_series')
 

--- a/ckanext/gobar_theme/templates/config/config_16_google_tag_manager.html
+++ b/ckanext/gobar_theme/templates/config/config_16_google_tag_manager.html
@@ -3,7 +3,7 @@
 
     <h1>Google Tag Manager</h1>
 
-    <form method="post" action="" data-module="basic-form">
+    <form id="google-tag-manager" method="post" action="" data-module="basic-form">
 
         <h2>Id del container de Google Tag Manager</h2>
         <input type="text" name="container-id" value="{{ h.get_gtm_code() }}">

--- a/ckanext/gobar_theme/templates/config/config_16_google_tag_manager.html
+++ b/ckanext/gobar_theme/templates/config/config_16_google_tag_manager.html
@@ -1,0 +1,16 @@
+{% extends "config/config_base.html" %}
+{% block config %}
+
+    <h1>Google Tag Manager</h1>
+
+    <form method="post" action="" data-module="basic-form">
+
+        <h2>Id del container de Google Tag Manager</h2>
+        <input type="text" name="container-id" value="{{ h.get_gtm_code() }}">
+
+        <div class="submit-container">
+            <button class="submit-button" type="submit" name="save">GUARDAR</button>
+        </div>
+    </form>
+
+{% endblock -%}

--- a/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
+++ b/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
@@ -7,6 +7,7 @@
 
         <h2>Id de Google Analytics</h2>
         <input type="text" name="id" value="{{ h.get_google_analytics_id() }}">
+        <p>En el caso de guardar un id vacío, se defaulteará al valor existente en el archivo de configuración.</p>
 
         <div class="submit-container">
             <button class="submit-button" type="submit" name="save">GUARDAR</button>

--- a/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
+++ b/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
@@ -3,7 +3,7 @@
 
     <h1>Google Analytics</h1>
 
-    <form method="post" action="" data-module="basic-form">
+    <form id="google-analytics" method="post" action="" data-module="basic-form">
 
         <h2>Id del container de Google Tag Manager</h2>
         <input type="text" name="id" value="{{ h.get_google_analytics_id() }}">

--- a/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
+++ b/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
@@ -1,0 +1,16 @@
+{% extends "config/config_base.html" %}
+{% block config %}
+
+    <h1>Google Analytics</h1>
+
+    <form method="post" action="" data-module="basic-form">
+
+        <h2>Id del container de Google Tag Manager</h2>
+        <input type="text" name="id" value="{{ h.get_google_analytics_id() }}">
+
+        <div class="submit-container">
+            <button class="submit-button" type="submit" name="save">GUARDAR</button>
+        </div>
+    </form>
+
+{% endblock -%}

--- a/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
+++ b/ckanext/gobar_theme/templates/config/config_17_google_analytics.html
@@ -5,7 +5,7 @@
 
     <form id="google-analytics" method="post" action="" data-module="basic-form">
 
-        <h2>Id del container de Google Tag Manager</h2>
+        <h2>Id de Google Analytics</h2>
         <input type="text" name="id" value="{{ h.get_google_analytics_id() }}">
 
         <div class="submit-container">

--- a/ckanext/gobar_theme/templates/config/navbar.html
+++ b/ckanext/gobar_theme/templates/config/navbar.html
@@ -76,6 +76,10 @@
            class="section-link {{ 'active' if c.action == 'edit_google_dataset_search' else '' }}">
             Google Dataset Search
         </a>
+        <a href="{{ h.url_for(controller='ckanext.gobar_theme.config_controller:GobArConfigController', action='edit_google_tag_manager') }}"
+           class="section-link {{ 'active' if c.action == 'edit_google_tag_manager' else '' }}">
+            Google Tag Manager
+        </a>
     </div>
 
     <div class="links-section guide-link">

--- a/ckanext/gobar_theme/templates/config/navbar.html
+++ b/ckanext/gobar_theme/templates/config/navbar.html
@@ -80,6 +80,10 @@
            class="section-link {{ 'active' if c.action == 'edit_google_tag_manager' else '' }}">
             Google Tag Manager
         </a>
+        <a href="{{ h.url_for(controller='ckanext.gobar_theme.config_controller:GobArConfigController', action='edit_google_analytics') }}"
+           class="section-link {{ 'active' if c.action == 'edit_google_analytics' else '' }}">
+            Google Analytics
+        </a>
     </div>
 
     <div class="links-section guide-link">

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -107,6 +107,8 @@ googleanalytics.id = UA-101681828-1
 googleanalytics_resource_prefix = /downloads/
 googleanalytics.domain = auto
 
+ckan.google_tag_manager.gtm_container_id = id-default
+
 # Logging configuration
 [loggers]
 keys = root, ckan, sqlalchemy

--- a/ckanext/gobar_theme/tests/tests_configuration.py
+++ b/ckanext/gobar_theme/tests/tests_configuration.py
@@ -49,3 +49,18 @@ class TestGoogleDatasetSearch(TestConfiguration):
 
         form = response.forms['google-dataset-search']
         nt.assert_equals(form['enable_structured_data'].checked, True)
+
+
+class TestGoogleTagManager(TestConfiguration):
+
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def test_id_can_be_configured(self):
+        env, response = self.get_page_response('/configurar/google_tag_manager', admin_required=True)
+        form = response.forms['google-tag-manager']
+        nt.assert_equals(form['container-id'].value, "id-default")
+        response = \
+            self.edit_form_value(response, field_name='container-id', field_type='text', value="id-custom")
+
+        form = response.forms['google-tag-manager']
+        nt.assert_equals(form['container-id'].value, "id-custom")

--- a/ckanext/gobar_theme/tests/tests_configuration.py
+++ b/ckanext/gobar_theme/tests/tests_configuration.py
@@ -58,9 +58,26 @@ class TestGoogleTagManager(TestConfiguration):
     def test_id_can_be_configured(self):
         env, response = self.get_page_response('/configurar/google_tag_manager', admin_required=True)
         form = response.forms['google-tag-manager']
+        # Chequeamos que el valor default sea utilizado
         nt.assert_equals(form['container-id'].value, "id-default")
         response = \
             self.edit_form_value(response, field_name='container-id', field_type='text', value="id-custom")
 
         form = response.forms['google-tag-manager']
         nt.assert_equals(form['container-id'].value, "id-custom")
+
+
+class TestGoogleAnalytics(TestConfiguration):
+
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def test_id_can_be_configured(self):
+        env, response = self.get_page_response('/configurar/google_analytics', admin_required=True)
+        form = response.forms['google-analytics']
+        # Chequeamos que el valor default sea utilizado
+        nt.assert_equals(form['id'].value, "UA-101681828-1")
+        response = \
+            self.edit_form_value(response, field_name='id', field_type='text', value="id-custom")
+
+        form = response.forms['google-analytics']
+        nt.assert_equals(form['id'].value, "id-custom")


### PR DESCRIPTION
Los valores ingresados se guardarán junto con el resto de la configuración del portal (`settings.json`).

Para los casos donde se haya especificado un valor en el `production.ini`, se lo utiliza como default cuando no haya ningún valor guardado para la configuración.

Closes #367.