### PR TITLE
Autogenerar landing page sin puerto

### DIFF
--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -602,6 +602,6 @@ def search_for_value_in_config_file(field):
 
 def remove_port_from_url(url):
     parsed_url = urlparse(url)
-    return "{0}{1}/{2}".format("{}://".format(parsed_url.scheme if parsed_url.scheme else ""),
+    return "{0}{1}{2}".format("{}://".format(parsed_url.scheme if parsed_url.scheme else ""),
                                parsed_url.hostname,
                                parsed_url.path)

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -600,9 +600,8 @@ def search_for_value_in_config_file(field):
         return ''
 
 
-def get_domain_name():
-    site_url = config.get('ckan.site_url')
-    parsed_url = urlparse(site_url)
-    if parsed_url.hostname:
-        return "{0}{1}".format("{}://".format(parsed_url.scheme if parsed_url.scheme else ""), parsed_url.hostname)
-    return parsed_url.path
+def remove_port_from_url(url):
+    parsed_url = urlparse(url)
+    return "{0}{1}/{2}".format("{}://".format(parsed_url.scheme if parsed_url.scheme else ""),
+                               parsed_url.hostname,
+                               parsed_url.path)

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -603,7 +603,7 @@ def search_for_value_in_config_file(field):
 
 def remove_port_from_url(url):
     parsed_url = urlparse(url)
-    return "{0}{1}{2}".format("{}://".format(parsed_url.scheme if parsed_url.scheme else ""),
+    return "{0}{1}{2}".format("{}://".format(parsed_url.scheme) if parsed_url.scheme else "",
                                parsed_url.hostname,
                                parsed_url.path)
 

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -598,3 +598,11 @@ def search_for_value_in_config_file(field):
         return value.replace(field, '')[1:]
     except:
         return ''
+
+
+def get_domain_name():
+    site_url = config.get('ckan.site_url')
+    parsed_url = urlparse(site_url)
+    if parsed_url.hostname:
+        return "{0}{1}".format("{}://".format(parsed_url.scheme if parsed_url.scheme else ""), parsed_url.hostname)
+    return parsed_url.path

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -104,6 +104,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_default_series_api_url': gobar_helpers.get_default_series_api_url,
             'create_or_update_cron_job': gobar_helpers.create_or_update_cron_job,
             'get_current_terminal_username': gobar_helpers.get_current_terminal_username,
+            'get_domain_name': gobar_helpers.get_domain_name,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -104,7 +104,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_default_series_api_url': gobar_helpers.get_default_series_api_url,
             'create_or_update_cron_job': gobar_helpers.create_or_update_cron_job,
             'get_current_terminal_username': gobar_helpers.get_current_terminal_username,
-            'get_domain_name': gobar_helpers.get_domain_name,
+            'remove_port_from_url': gobar_helpers.remove_port_from_url,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
@@ -16,7 +16,7 @@
         </div>
     </div>
 
-    {% set domain = h.url_for(controller='package', action='read', id='', qualified=true) %}
+    {% set domain = h.get_domain_name() %}
     {% set url_value = data.url if data.url else domain %}
 
     {{ form.textarea('author', label='* Responsable', id='field-author', value=data.author, error=errors.author, classes=['control-full'], rows=2, placeholder="Ej. Ministerio de Modernización. Secretaría de Gestión e Innovación Pública. Subsecretaría de Innovación Pública y Gobierno Abierto.") }}

--- a/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
@@ -16,7 +16,7 @@
         </div>
     </div>
 
-    {% set domain = h.get_domain_name() %}
+    {% set domain = h.remove_port_from_url(h.url_for(controller='package', action='read', id='', qualified=true) %}
     {% set url_value = data.url if data.url else domain %}
 
     {{ form.textarea('author', label='* Responsable', id='field-author', value=data.author, error=errors.author, classes=['control-full'], rows=2, placeholder="Ej. Ministerio de Modernización. Secretaría de Gestión e Innovación Pública. Subsecretaría de Innovación Pública y Gobierno Abierto.") }}

--- a/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/gobar_theme/templates/package/snippets/package_metadata_fields.html
@@ -16,7 +16,7 @@
         </div>
     </div>
 
-    {% set domain = h.remove_port_from_url(h.url_for(controller='package', action='read', id='', qualified=true) %}
+    {% set domain = h.remove_port_from_url(h.url_for(controller='package', action='read', id='', qualified=true)) %}
     {% set url_value = data.url if data.url else domain %}
 
     {{ form.textarea('author', label='* Responsable', id='field-author', value=data.author, error=errors.author, classes=['control-full'], rows=2, placeholder="Ej. Ministerio de Modernización. Secretaría de Gestión e Innovación Pública. Subsecretaría de Innovación Pública y Gobierno Abierto.") }}

--- a/ckanext/gobar_theme/tests/tests_datasets.py
+++ b/ckanext/gobar_theme/tests/tests_datasets.py
@@ -74,3 +74,10 @@ class TestDatasets(TestAndino.TestAndino):
         nt.assert_equal(pkg.resources[0].url, u'http://1.com')
         pkg = self.update_package_using_forms(pkg.name)
         nt.assert_equal(pkg.notes, u'New description')
+
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def test_package_form_correctly_autogenerates_landing_page(self):
+        env, response = self.get_page_response('/dataset/new')
+        form = response.forms['dataset-edit']
+        nt.assert_equals(form['url'].value, 'http://example.com/dataset/')


### PR DESCRIPTION
El campo `landingPage` del formulario de datasets, cuando se crea un dataset nuevo, está autogenerando un valor el cual consiste en la URL que se le dará al mismo. El problema existente consiste en la creación de dicha URL incluyendo el número de puerto.

Se creó una nueva función para generar una URL en base a otra (la cual llega por parámetro) sin que el puerto figure.

## Cómo testear la solución

* Tener una instancia levantada de Andino utilizando el branch de portal-andino-theme correspondiente al issue
* Ingresar al formulario de creación de datasets
* Asegurarse de que el puerto no esté dentro de la URL del campo _Página de referencia_

Closes #386.