### PR TITLE
Implementar comando de subida de recursos al datastore

### DIFF
--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -592,7 +592,11 @@ def delete_column_from_csv_file(csv_path, column_name):
         except ValueError:
             # No existe una columna con el nombre que llegó por parámetro -> se usará el csv tal y como está
             return
+        source.seek(0)
+        list_with_rows = []
+        for r in rdr:
+            list_with_rows.append(tuple(x for x in r if column_position != r.index(x)))
     with open(csv_path, 'wb') as result:
         wtr = csv.writer(result)
-        for r in rdr:
-            wtr.writerow(tuple(x for x in r if column_position != r.index(x)))
+        for r in list_with_rows:
+            wtr.writerow(tuple(x for x in r))

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -582,7 +582,7 @@ def search_for_value_in_config_file(field):
         return ''
 
 
-def delete_column_from_csv_file(csv_path, final_file_path, column_name):
+def delete_column_from_csv_file(csv_path, column_name):
     '''
     :param csv_path: path del archivo csv a leer
     :param final_file_path: path a utilizar para el archivo csv final (debe ser diferente al path del csv original)
@@ -592,17 +592,13 @@ def delete_column_from_csv_file(csv_path, final_file_path, column_name):
     with open(csv_path, 'rb') as source:
         rdr = csv.reader(source)
         first_row = next(rdr)
-        pos = None
+        column_position = None
         try:
-            pos = first_row.index(column_name)
+            column_position = first_row.index(column_name)
         except ValueError:
-            # No existe una columna con el nombre que llegó por parámetro -> se usará el csv original
-            return csv_path
-        source.seek(0)
-        with open(final_file_path, 'wb') as result:
-            wtr = csv.writer(result)
-            for r in rdr:
-                wtr.writerow(tuple(x for x in r if pos != r.index(x)))
-    # Ya que tenemos el csv sin la columna indeseada preparado, borramos el original
-    os.remove(csv_path)
-    return final_file_path
+            # No existe una columna con el nombre que llegó por parámetro -> se usará el csv tal y como está
+            return
+    with open(csv_path, 'wb') as result:
+        wtr = csv.writer(result)
+        for r in rdr:
+            wtr.writerow(tuple(x for x in r if column_position != r.index(x)))

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -595,7 +595,7 @@ def delete_column_from_csv_file(csv_path, column_name):
         source.seek(0)
         list_with_rows = []
         for r in rdr:
-            list_with_rows.append(tuple(x for x in r if column_position != r.index(x)))
+            list_with_rows.append(tuple((r[x] for x in range(len(r)) if x != column_position)))
     with open(csv_path, 'wb') as result:
         wtr = csv.writer(result)
         for r in list_with_rows:

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -583,12 +583,6 @@ def search_for_value_in_config_file(field):
 
 
 def delete_column_from_csv_file(csv_path, column_name):
-    '''
-    :param csv_path: path del archivo csv a leer
-    :param final_file_path: path a utilizar para el archivo csv final (debe ser diferente al path del csv original)
-    :param column_name: nombre de la columna a eliminar
-    :return: path del csv final (si la columna no existe, simplemente se usa el original)
-    '''
     with open(csv_path, 'rb') as source:
         rdr = csv.reader(source)
         first_row = next(rdr)

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -18,6 +18,7 @@ from dateutil import parser, tz
 from pydatajson.core import DataJson
 from pylons.config import config
 import logging
+import csv
 
 logger = logging.getLogger(__name__)
 
@@ -579,3 +580,29 @@ def search_for_value_in_config_file(field):
         return value.replace(field, '')[1:]
     except:
         return ''
+
+
+def delete_column_from_csv_file(csv_path, final_file_path, column_name):
+    '''
+    :param csv_path: path del archivo csv a leer
+    :param final_file_path: path a utilizar para el archivo csv final (debe ser diferente al path del csv original)
+    :param column_name: nombre de la columna a eliminar
+    :return: path del csv final (si la columna no existe, simplemente se usa el original)
+    '''
+    with open(csv_path, 'rb') as source:
+        rdr = csv.reader(source)
+        first_row = next(rdr)
+        pos = None
+        try:
+            pos = first_row.index(column_name)
+        except ValueError:
+            # No existe una columna con el nombre que llegó por parámetro -> se usará el csv original
+            return csv_path
+        source.seek(0)
+        with open(final_file_path, 'wb') as result:
+            wtr = csv.writer(result)
+            for r in rdr:
+                wtr.writerow(tuple(x for x in r if pos != r.index(x)))
+    # Ya que tenemos el csv sin la columna indeseada preparado, borramos el original
+    os.remove(csv_path)
+    return final_file_path

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -6,7 +6,6 @@ from ckan.lib import cli
 from ckanapi import RemoteCKAN, LocalCKAN
 from pylons.config import config
 import ckanext.gobar_theme.helpers as gobar_helpers
-from ckanext.gobar_theme.lib.datajson_actions import get_data_json_contents
 
 import logging
 

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -137,9 +137,9 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                             file_content = requests.get('{0}/datastore/dump/{1}'.format(site_url, resource_id)).content
                             if not file_content:
                                 raise ValueError('Archivo proveniente de Datastore sin contenido')
-                            with open(resource_file_path, 'w+') as resource_file:
+                            with open(resource_file_path, 'wb') as resource_file:
                                 resource_file.write(file_content)
-                            with open(resource_file_path, 'r+') as resource_file:
+                            with open(resource_file_path, 'rb') as resource_file:
                                 data = {'id': resource_id, 'upload': resource_file}
                                 rc.action.resource_patch(**data)
                             os.remove(resource_file_path)

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -135,7 +135,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                         resource_file_path = '/tmp/{}'.format(filename)
                         try:
                             response = requests.get('{0}/datastore/dump/{1}'.format(site_url, resource_id))
-                            if 'text/csv' in response.headers.get('Content-Type'):
+                            if 'text/html' in response.headers.get('Content-Type'):
                                 raise TypeError("El archivo no se encuentra en el Datastore")
                             file_content = response.content
                             if not file_content:

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -103,7 +103,14 @@ class ReuploadResourcesFiles(cli.CkanCommand):
 
     def command(self):
         self._load_config()
-        datajson = get_data_json_contents()
+        try:
+            with open('/var/lib/ckan/theme_config/datajson_cache.json', 'r+') as file:
+                datajson = file.read()
+        except IOError:
+            LOGGER.info('No existe una caché del data.json.')
+            # TODO: buscar los recursos de otra forma
+            return None
+
         total_resources_to_patch = 0
         ids_of_unsuccessfully_patched_resources = []
 

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -134,7 +134,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                         total_resources_to_patch += 1
                         resource_file_path = '/tmp/{}'.format(filename)
                         try:
-                            file_content = requests.get('{0}/datastore/dump/{1}').content
+                            file_content = requests.get('{0}/datastore/dump/{1}'.format(site_url, resource_id)).content
                             if not file_content:
                                 raise ValueError('Archivo proveniente de Datastore sin contenido')
                             with open(resource_file_path, 'w+') as resource_file:

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -2,7 +2,7 @@
 import os
 import sys
 import json
-import urllib2
+import requests
 from ckan import model, logic
 from ckan.lib import cli
 from ckanapi import RemoteCKAN, LocalCKAN
@@ -134,8 +134,9 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                         total_resources_to_patch += 1
                         resource_file_path = '/tmp/{}'.format(filename)
                         try:
-                            file_content = \
-                                urllib2.urlopen('{0}/datastore/dump/{1}'.format(site_url, resource_id)).read()
+                            file_content = requests.get('{0}/datastore/dump/{1}').content
+                            if not file_content:
+                                raise ValueError('Archivo proveniente de Datastore sin contenido')
                             with open(resource_file_path, 'w+') as resource_file:
                                 resource_file.write(file_content)
                                 data = {'id': resource_id, 'upload': resource_file}

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -133,7 +133,6 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                         resource_id = resource.get('identifier')
                         total_resources_to_patch += 1
                         resource_file_path = '/tmp/datastore_file'
-                        resource_final_file_path = '/tmp/{}'.format(filename)
                         try:
                             response = requests.get('{0}/datastore/dump/{1}'.format(site_url, resource_id))
                             if 'text/html' in response.headers.get('Content-Type'):
@@ -144,9 +143,8 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                             with open(resource_file_path, 'wb') as resource_file:
                                 resource_file.write(file_content)
                             # Buscamos la columna '_id' generada como campo en el Datastore; si existe, se la borra
-                            gobar_helpers.delete_column_from_csv_file(
-                                resource_file_path, resource_final_file_path, '_id')
-                            with open(resource_final_file_path, 'rb') as resource_file:
+                            gobar_helpers.delete_column_from_csv_file(resource_file_path, '_id')
+                            with open(resource_file_path, 'rb') as resource_file:
                                 data = {'id': resource_id, 'upload': resource_file}
                                 rc.action.resource_patch(**data)
                         except Exception:
@@ -156,8 +154,6 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                                                                   'function_line': function_line}
                         # Borramos cualquier archivo que pueda haber quedado realizando la operación
                         if os.path.isfile(resource_file_path):
-                            os.remove(resource_file_path)
-                        if os.path.isfile(resource_final_file_path):
                             os.remove(resource_file_path)
         LOGGER.info('Se actualizaron {0} de {1} recursos locales.'
                     .format(total_resources_to_patch - len(ids_of_unsuccessfully_patched_resources),

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -151,7 +151,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                             ids_of_unsuccessfully_patched_resources.append(resource_id)
                             error_type, error_text, function_line = sys.exc_info()
                             errors_while_patching[resource_id] = {'error_type': error_type, 'error_text': error_text,
-                                                                  'function_line': function_line}
+                                                                  'function_line': function_line.tb_lineno}
                         # Borramos cualquier archivo que pueda haber quedado realizando la operación
                         if os.path.isfile(resource_file_path):
                             os.remove(resource_file_path)

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -137,7 +137,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                             with open(resource_file_path, 'w+') as resource_file:
                                 resource_file.write(file_content)
                                 data = {'id': resource_id, 'upload': resource_file}
-                                rc.resource_patch(**data)
+                                rc.action.resource_patch(**data)
                             os.remove(resource_file_path)
                         except Exception:
                             ids_of_unsuccessfully_patched_resources.append(resource_id)

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -1,5 +1,6 @@
 #! coding: utf-8
 import os
+import json
 import urllib2
 from ckan import model, logic
 from ckan.lib import cli
@@ -104,7 +105,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
         self._load_config()
         try:
             with open('/var/lib/ckan/theme_config/datajson_cache.json', 'r+') as file:
-                datajson = file.read()
+                datajson = json.loads(file.read())
         except IOError:
             LOGGER.info('No existe una caché del data.json.')
             # TODO: buscar los recursos de otra forma

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -103,7 +103,6 @@ class ReuploadResourcesFiles(cli.CkanCommand):
     summary = "Conseguir y resubir archivos de los recursos locales del portal"
 
     def __init__(self):
-        super(ReuploadResourcesFiles, self).__init__()
         self.total_resources_to_patch = 0
         self.ids_of_unsuccessfully_patched_resources = []
         self.errors_while_patching = {}

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -1,12 +1,12 @@
 #! coding: utf-8
 import os
 import urllib2
-import tempfile
 from ckan import model, logic
 from ckan.lib import cli
 from ckanapi import RemoteCKAN, LocalCKAN
 from pylons.config import config
 import ckanext.gobar_theme.helpers as gobar_helpers
+from ckanext.gobar_theme.lib.datajson_actions import get_data_json_contents
 
 import logging
 
@@ -103,7 +103,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
 
     def command(self):
         self._load_config()
-        datajson = {}
+        datajson = get_data_json_contents()
         total_resources_to_patch = 0
         ids_of_unsuccessfully_patched_resources = []
 
@@ -125,7 +125,8 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                         total_resources_to_patch += 1
                         resource_file_path = '/tmp/{}'.format(filename)
                         try:
-                            file_content = urllib2.urlopen('{0}/datastore/dump/{1}'.format(site_url, filename)).read()
+                            file_content = \
+                                urllib2.urlopen('{0}/datastore/dump/{1}'.format(site_url, resource_id)).read()
                             with open(resource_file_path, 'w+') as resource_file:
                                 resource_file.write(file_content)
                                 data = {'id': resource_id, 'upload': resource_file}

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -132,7 +132,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                     if filename:
                         resource_id = resource.get('identifier')
                         total_resources_to_patch += 1
-                        resource_file_path = '/tmp/datastore_file'
+                        resource_file_path = '/tmp/{}'.format(filename)
                         try:
                             response = requests.get('{0}/datastore/dump/{1}'.format(site_url, resource_id))
                             if 'text/html' in response.headers.get('Content-Type'):

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -139,6 +139,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                                 raise ValueError('Archivo proveniente de Datastore sin contenido')
                             with open(resource_file_path, 'w+') as resource_file:
                                 resource_file.write(file_content)
+                            with open(resource_file_path, 'r+') as resource_file:
                                 data = {'id': resource_id, 'upload': resource_file}
                                 rc.action.resource_patch(**data)
                             os.remove(resource_file_path)

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -1,5 +1,6 @@
 #! coding: utf-8
 import os
+import sys
 import json
 import urllib2
 from ckan import model, logic
@@ -113,6 +114,7 @@ class ReuploadResourcesFiles(cli.CkanCommand):
 
         total_resources_to_patch = 0
         ids_of_unsuccessfully_patched_resources = []
+        errors_while_patching = {}
 
         # Usando un LocalCKAN obtengo el apikey del usuario default
         lc = LocalCKAN()
@@ -141,11 +143,16 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                             os.remove(resource_file_path)
                         except Exception:
                             ids_of_unsuccessfully_patched_resources.append(resource_id)
+                            error_type, error_text, function_line = sys.exc_info()
+                            errors_while_patching[resource_id] = {'error_type': error_type, 'error_text': error_text,
+                                                                  'function_line': function_line}
                             if os.path.isfile(resource_file_path):
                                 os.remove(resource_file_path)
         LOGGER.info('Se actualizaron {0} de {1} recursos locales.'
                     .format(total_resources_to_patch - len(ids_of_unsuccessfully_patched_resources),
                             total_resources_to_patch))
         if ids_of_unsuccessfully_patched_resources:
-            LOGGER.error('IDs de los recursos que no fueron actualizados: {}'
+            LOGGER.error('Mostrando los recursos no actualizados y sus errores correspondientes: {}'
+                         .format(errors_while_patching))
+            LOGGER.error('Resumen: IDs de los recursos que no fueron actualizados: {}'
                          .format(ids_of_unsuccessfully_patched_resources))

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -102,13 +102,11 @@ class UpdateDatastoreCommand(cli.CkanCommand):
 class ReuploadResourcesFiles(cli.CkanCommand):
     summary = "Conseguir y resubir archivos de los recursos locales del portal"
 
-    def __init__(self):
+    def command(self):
+        self._load_config()
         self.total_resources_to_patch = 0
         self.ids_of_unsuccessfully_patched_resources = []
         self.errors_while_patching = {}
-
-    def command(self):
-        self._load_config()
         try:
             with open('/var/lib/ckan/theme_config/datajson_cache.json', 'r+') as file:
                 datajson = json.loads(file.read())

--- a/ckanext/gobar_theme/lib/cli.py
+++ b/ckanext/gobar_theme/lib/cli.py
@@ -134,7 +134,10 @@ class ReuploadResourcesFiles(cli.CkanCommand):
                         total_resources_to_patch += 1
                         resource_file_path = '/tmp/{}'.format(filename)
                         try:
-                            file_content = requests.get('{0}/datastore/dump/{1}'.format(site_url, resource_id)).content
+                            response = requests.get('{0}/datastore/dump/{1}'.format(site_url, resource_id))
+                            if 'text/csv' in response.headers.get('Content-Type'):
+                                raise TypeError("El archivo no se encuentra en el Datastore")
+                            file_content = response.content
                             if not file_content:
                                 raise ValueError('Archivo proveniente de Datastore sin contenido')
                             with open(resource_file_path, 'wb') as resource_file:

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         generate-data-json = ckanext.gobar_theme.lib.cli:GenerateDataJsonCommand
         generate-catalog-xlsx= ckanext.gobar_theme.lib.cli:GenerateCatalogXlsxCommand
         update-datastore= ckanext.gobar_theme.lib.cli:UpdateDatastoreCommand
+        reupload-resources-files= ckanext.gobar_theme.lib.cli:ReuploadResourcesFiles
     ''',
 
     # If you are changing from the default layout of your extension, you may


### PR DESCRIPTION
Se creó un CKAN command encargado de buscar recursos locales, descargar sus archivos correspondientes guardados en Datastore, y realizar un patch de cada recurso actualizando su archivo con lo conseguido.
Se considera que un recurso fue actualizado sólo en casos donde se hayan dado las siguientes condiciones:
* El recurso es local
* El archivo que le corresponde al recurso existe en el Datastore
* El contenido del archivo descargado del Datastore existe
* Se ejecutó la función `resource_patch`

Si alguna condición no se cumple, la actualización será interrumpida.
Se loguearán los ID de los recursos que no pudieron ser actualizados, junto con el tipo de error.

## Cómo probar la solución

* Tener levantada una instancia de Andino usando el branch master de portal-andino-theme, y hacer un checkout en base a un commit sin el fix del issue #364 (**dentro del container**, ejecutar: `cd /usr/lib/ckan/default/src/ckanext-gobar-theme && git fetch && git checkout f0edcd852809cbfa6b79ad69821c403628605d25 && . /usr/lib/ckan/default/bin/activate && pip install python-crontab && apachectl restart`)
* Crear un dataset
* Crear y guardar un recurso para el dataset nuevo con un archivo de formato _csv_ (asegurarse que no está vacío); 
  * Asegurarse de que el archivo fue subido al Datastore (el preview debería aparecer en la vista del recurso)
  * Intentar descargar el archivo en la vista del recurso (debería ser el mismo archivo que se subió)
* Crear y guardar otro recurso con un csv
  * Esperar y chequear que el archivo fue guardado en el Datastore
  * Ingresar al formulario de edición del recurso y darle guardar _sin modificar ningún dato_
  * Intentar descargar el archivo en la vista del recurso (el browser _debe_ tirar un error de too many redirects)
* Hacer un checkout al branch correspondiente al issue (`cd /usr/lib/ckan/default/src/ckanext-gobar-theme && git checkout 364b-descargar-recursos-editados-con-ckan-command && pip install -e . && apachectl restart`)
* Crear dos recursos con un csv siguiendo la misma estrategia utilizada para los recursos anteriores; la diferencia es que el recurso editado no tirará error al intentar descargar su archivo
* Una vez que *todos* los archivos de los recursos estén en el Datastore, ejecutar `/usr/lib/ckan/default/bin/paster --plugin=ckan reupload-resources-files --config=/etc/ckan/default/production.ini`
  * Debe haber aparecido en la pantalla que se actualizaron los 4 recursos
* Descargar el archivo de los 4 recursos; ninguno debe estar vacío 

Closes #385.