### PR TITLE
Botón para subir archivo de un recurso en Firefox

### DIFF
--- a/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
+++ b/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
@@ -2,7 +2,7 @@ $(function () {
 
     var file_or_url_was_removed = false;
 
-    $(document).on('click', '.url-button', function () {
+    $(document).on('click', '.url-button', function (e) {
         if($(this).siblings("#resource-upload-url").length > 0) {  // Aseguro que se esté clickeando el botón de URL
             if ($('#distribution-type').val() !== 'api'){
                 $('#form-file-name').show();
@@ -12,12 +12,12 @@ $(function () {
         }
     });
 
-    $(document).on('click', '.file-upload-label', function () {
+    $(document).on('click', '.file-upload-label', function (e) {
         $('input#' + $(event.target).parent().attr('for')).click();  // Disparo el click en el input[type=file]
         $('option.distribution-type-option[value="file"]').val('file.upload');
     });
 
-    $(document).on('click', 'a.btn-remove-url', function () {
+    $(document).on('click', 'a.btn-remove-url', function (e) {
         if ($(this).siblings("input#resource-upload-url").length > 0) {  // Aseguro que se esté cerrando el input de URL
             $('#form-file-name').hide();
             $('input#field-file-name').val('');
@@ -25,7 +25,7 @@ $(function () {
         }
     });
 
-    $('form#resource-edit').on('submit', function () {
+    $('form#resource-edit').on('submit', function (e) {
         if (file_or_url_was_removed === false){
             $('input[name=clear_upload]').remove()
         }

--- a/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
+++ b/ckanext/gobar_theme/js/package/resource/urls_and_icons.js
@@ -13,7 +13,7 @@ $(function () {
     });
 
     $(document).on('click', '.file-upload-label', function (e) {
-        $('input#' + $(event.target).parent().attr('for')).click();  // Disparo el click en el input[type=file]
+        $('input#' + $(e.target).parent().attr('for')).click();  // Disparo el click en el input[type=file]
         $('option.distribution-type-option[value="file"]').val('file.upload');
     });
 


### PR DESCRIPTION
Closes #393.

### Cómo probar la solución

1) Levantar una instancia de andino con el branch de portal-andino-theme correspondiente al issue
2) Entrar al formulario de creación/edición de un recurso
3) Intentar subir un archivo

El botón "SUBIR" debería funcionar correctamente, permitiendo seleccionar un archivo local.