### PR TITLE
Crear json con licencias

### DIFF
--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,7 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
-sed -i 's/file_path_for_licenses_json/${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i 's/file_path_for_licenses_json/$TRAVIS_BUILD_DIR\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,7 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
-sed -i "s;file_path_for_licenses_json;$TRAVIS_BUILD_DIR\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json;g" /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i "s;file_path_for_licenses_json;file\/\/$TRAVIS_BUILD_DIR\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json;g" /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,7 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
-sed -i "s/file_path_for_licenses_json/${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g" /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i "s;file_path_for_licenses_json;$TRAVIS_BUILD_DIR\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json;g" /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,7 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
-sed -i 's/file_path_for_licenses_json/@${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i 's/file_path_for_licenses_json/${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,6 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i 's/@file_path_for_licenses_json/@${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,7 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
-sed -i "s;file_path_for_licenses_json;file\/\/$TRAVIS_BUILD_DIR\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json;g" /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i "s;file_path_for_licenses_json;file:\/\/$TRAVIS_BUILD_DIR\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json;g" /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,7 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
-sed -i 's/file_path_for_licenses_json/$TRAVIS_BUILD_DIR\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i "s/file_path_for_licenses_json/${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g" /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -5,7 +5,7 @@ set -e
 sudo -u postgres psql -c "CREATE DATABASE datastore_test WITH OWNER ckan_default;"
 sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sed -i 's/@db/@localhost/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
-sed -i 's/@file_path_for_licenses_json/@${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
+sed -i 's/file_path_for_licenses_json/@${TRAVIS_BUILD_DIR}\/ckanext\/gobar_theme\/tests\/tests_config\/licenses.json/g' /home/travis/build/datosgobar/portal-andino-theme/ckanext/gobar_theme/tests/tests_config/test-core.ini
 
 cd ${TRAVIS_BUILD_DIR}/ckanext/gobar_theme/tests/
 export CKAN_LIB=/var/lib/ckan

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -294,7 +294,7 @@ def get_license(id):
 
 def get_license_title(license_id):
     for license in license_options():
-        if license.id == license_id:
+        if id_belongs_to_license(license_id, license):
             return license.title
     return None
 

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -4,6 +4,7 @@ from HTMLParser import HTMLParser
 import ckan.lib.helpers as ckan_helpers
 import ckan.lib.search as search
 import ckan.logic as logic
+import ckan.model as model
 import moment
 import subprocess
 from ckan.common import request, c, g, _
@@ -273,18 +274,22 @@ def json_loads(json_string):
 
 
 def license_options(existing_license_id=None):
-    ckan_licenses_list = ckan_helpers.license_options()
-    custom_licenses_list = [(u"CC-BY-4.0", u"Creative Commons Attribution 4.0")]  # Orden: 1) código - 2) título/nombre
-    final_license_list = list(set.union(set(ckan_licenses_list), custom_licenses_list))
-    final_license_list = map(lambda element: {"name": element[1], "code": element[0]}, final_license_list)
-    return sorted(final_license_list, key=lambda x: x["name"])
+    # En lugar de retornar una lista de tuplas, como hace el código original de CKAN, retorno una lista de licencias
+    # para soportar el uso del campo 'license_ids'
+    register = model.Package.get_license_register()
+    sorted_licenses = sorted(register.values(), key=lambda x: x.title)
+    return sorted_licenses
 
 
 def get_license_title(license_id):
     for license in license_options():
-        if license['code'] == license_id:
-            return license['name']
+        if license.get('id') == license_id:
+            return license.get('title')
     return None
+
+
+def id_belongs_to_license(id, license):
+    return id == license.id or (hasattr(license, 'legacy_ids') and id in license.legacy_ids)
 
 
 def update_frequencies(freq_id=None):

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -281,15 +281,22 @@ def license_options(existing_license_id=None):
     return sorted_licenses
 
 
+def id_belongs_to_license(id, license):
+    return id == license.id or (hasattr(license, 'legacy_ids') and id in license.legacy_ids)
+
+
+def get_license(id):
+    for license in license_options():
+        if id_belongs_to_license(id, license):
+            return license
+    return None
+
+
 def get_license_title(license_id):
     for license in license_options():
         if license.id == license_id:
             return license.title
     return None
-
-
-def id_belongs_to_license(id, license):
-    return id == license.id or (hasattr(license, 'legacy_ids') and id in license.legacy_ids)
 
 
 def update_frequencies(freq_id=None):

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -283,8 +283,8 @@ def license_options(existing_license_id=None):
 
 def get_license_title(license_id):
     for license in license_options():
-        if license.get('id') == license_id:
-            return license.get('title')
+        if license.id == license_id:
+            return license.title
     return None
 
 

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -71,6 +71,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'json_loads': gobar_helpers.json_loads,
             'license_options': gobar_helpers.license_options,
             'get_license_title': gobar_helpers.get_license_title,
+            'id_belongs_to_license': gobar_helpers.id_belongs_to_license,
             'update_frequencies': gobar_helpers.update_frequencies,
             'field_types': gobar_helpers.field_types,
             'distribution_types': gobar_helpers.distribution_types,

--- a/ckanext/gobar_theme/templates/config/config_12_metadata_portal.html
+++ b/ckanext/gobar_theme/templates/config/config_12_metadata_portal.html
@@ -42,7 +42,7 @@
         <select class="form-control" id="portal-license" name="metadata-license" style="margin-bottom: 30px;">
             {% set existing_license_id = h.get_theme_config('portal-metadata.license') %}
             {% for license in h.license_options(existing_license_id) %}
-                <option value="{{ license.code }}" {{ 'selected' if license.code == existing_license_id or ("CC-BY-4.0" == license.code and not existing_license_id) }}>{{ license.name }}</option>
+                <option value="{{ license.id }}" {{ 'selected' if h.id_belongs_to_license(existing_license_id, license) or ("CC-BY-4.0" == license.id and not existing_license_id) }}>{{ license.title }}</option>
             {% endfor %}
         </select>
 

--- a/ckanext/gobar_theme/templates/package/snippets/package_secondary_fields.html
+++ b/ckanext/gobar_theme/templates/package/snippets/package_secondary_fields.html
@@ -16,7 +16,7 @@
         <select id="field-license" name="license_id" data-module="autocomplete">
             {% set existing_license_id = data.get('license_id') %}
             {% for license in h.license_options(existing_license_id) %}
-                <option value="{{ license.code }}" {{ 'selected' if license.code == existing_license_id or ("CC-BY-4.0" == license.code and not existing_license_id) }}>{{ license.name }}</option>
+                <option value="{{ license.id }}" {{ 'selected' if h.id_belongs_to_license(existing_license_id, license) or ("CC-BY-4.0" == license.id and not existing_license_id) }}>{{ license.title }}</option>
             {% endfor %}
         </select>
         {% if error %}<span class="error-block">{{ error }}</span>{% endif %}

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form_license.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form_license.html
@@ -10,7 +10,7 @@
         <select id="field-license" name="license_id" data-module="autocomplete">
             {% set existing_license_id = data.get('license_id') %}
             {% for license in h.license_options(existing_license_id) %}
-                <option value="{{ license.code }}" {{ 'selected' if license.code == existing_license_id or ("CC-BY-4.0" == license.code and not existing_license_id) }}>{{ license.name }}</option>
+                <option value="{{ license.id }}" {{ 'selected' if h.id_belongs_to_license(existing_license_id, license) or ("CC-BY-4.0" == license.id and not existing_license_id) }}>{{ license.title }}</option>
             {% endfor %}
         </select>
         {% if error %}<span class="error-block">{{ error }}</span>{% endif %}

--- a/ckanext/gobar_theme/tests/tests_config/licenses.json
+++ b/ckanext/gobar_theme/tests/tests_config/licenses.json
@@ -1,0 +1,216 @@
+[
+  {
+    "domain_content": false,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "notspecified",
+    "is_generic": true,
+    "maintainer": "",
+    "od_conformance": "not reviewed",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "No se especificó la licencia",
+    "url": ""
+  },
+  {
+    "domain_content": false,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "",
+    "id": "PDDL-1.0",
+    "legacy_ids": [
+      "ODC-PDDL-1.0",
+      "odc-pddl"
+    ],
+    "maintainer": "",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)",
+    "url": "https://opendefinition.org/licenses/odc-pddl"
+  },
+  {
+    "domain_content": false,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "",
+    "id": "ODbL-1.0",
+    "legacy_ids": [
+      "odc-odbl"
+    ],
+    "maintainer": "",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Open Data Commons Open Database License 1.0 (ODbL)",
+    "url": "https://opendefinition.org/licenses/odc-odbl"
+  },
+  {
+    "domain_content": false,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "",
+    "id": "ODC-BY-1.0",
+    "legacy_ids": [
+      "odc-by"
+    ],
+    "maintainer": "Open Data Commons",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Open Data Commons Attribution License 1.0",
+    "url": "https://opendefinition.org/licenses/odc-by"
+  },
+  {
+    "domain_content": true,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "",
+    "id": "CC-BY-4.0",
+    "legacy_ids": [
+      "cc-by"
+    ],
+    "maintainer": "Creative Commons",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Creative Commons Attribution 4.0",
+    "url": "https://creativecommons.org/licenses/by/4.0/"
+  },
+  {
+    "domain_content": true,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "",
+    "id": "CC-BY-SA-4.0",
+    "legacy_ids": [
+      "cc-by-sa"
+    ],
+    "maintainer": "Creative Commons",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Creative Commons Attribution Share-Alike 4.0",
+    "url": "https://creativecommons.org/licenses/by-sa/4.0/"
+  },
+  {
+    "domain_content": true,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "GFDL-1.3-no-cover-texts-no-invariant-sections",
+    "legacy_ids": [
+      "gfdl"
+    ],
+    "maintainer": "Free Software Foundation",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "GNU Free Documentation License 1.3 sin textos de cubierta ni secciones invariantes",
+    "url": "https://opendefinition.org/licenses/gfdl"
+  },
+  {
+    "domain_content": true,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "other-open",
+    "is_generic": true,
+    "maintainer": "",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Otra (Abierta)",
+    "url": ""
+  },
+  {
+    "domain_content": true,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "other-pd",
+    "is_generic": true,
+    "maintainer": "",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Otra (Dominio Público)",
+    "url": ""
+  },
+  {
+    "domain_content": true,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "other-at",
+    "is_generic": true,
+    "maintainer": "",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Otra (Atribución)",
+    "url": ""
+  },
+  {
+    "domain_content": true,
+    "domain_data": true,
+    "domain_software": true,
+    "family": "",
+    "id": "OGL-UK-2.0",
+    "legacy_ids": [
+      "uk-ogl"
+    ],
+    "is_generic": false,
+    "maintainer": "UK Government",
+    "od_conformance": "approved",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Open Government Licence 2.0 (United Kingdom)",
+    "url": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
+  },
+  {
+    "domain_content": true,
+    "domain_data": true,
+    "domain_software": false,
+    "family": "Creative Commons",
+    "id": "CC-BY-NC-4.0",
+    "legacy_ids": [
+      "cc-nc"
+    ],
+    "maintainer": "Creative Commons",
+    "od_conformance": "rejected",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Creative Commons Attribution-NonCommercial 4.0 (cualquiera)",
+    "url": "https://creativecommons.org/licenses/by-nc/4.0/"
+  },
+  {
+    "domain_content": false,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "other-nc",
+    "is_generic": true,
+    "maintainer": "",
+    "od_conformance": "not reviewed",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Otra (No comercial)",
+    "url": ""
+  },
+  {
+    "domain_content": false,
+    "domain_data": false,
+    "domain_software": false,
+    "family": "",
+    "id": "other-closed",
+    "is_generic": true,
+    "maintainer": "",
+    "od_conformance": "not reviewed",
+    "osd_conformance": "not reviewed",
+    "status": "active",
+    "title": "Otra (No abierta)",
+    "url": ""
+  }
+]

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -51,7 +51,7 @@ ckan.site_title = CKAN
 ckan.site_logo = /images/ckan_logo_fullname_long.png
 ckan.site_description =
 package_form = standard
-licenses_group_url =
+licenses_group_url = need_some_text
 # pyamqplib or queue
 carrot_messaging_library = queue
 ckan.site_url = http://example.com

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -26,10 +26,10 @@ ckan.datapusher.url = http://datapusher.ckan.org/
 ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 
 ## Solr support
-solr_url = http://127.0.0.1:8983/solr/ckan
+solr_url = http://solr:8983/solr/ckan
 
 # Redis URL. Use a separate Redis database for testing.
-ckan.redis.url = redis://redis:6379/0
+ckan.redis.url = redis://localhost:6379/1
 
 ckan.auth.user_create_organizations = true
 ckan.auth.user_create_groups = true
@@ -54,7 +54,7 @@ package_form = standard
 licenses_group_url =
 # pyamqplib or queue
 carrot_messaging_library = queue
-ckan.site_url = http://test.ckan.net
+ckan.site_url = http://example.com
 package_new_return_url = http://localhost/dataset/<NAME>?test=new
 package_edit_return_url = http://localhost/dataset/<NAME>?test=edit
 ckan.extra_resource_fields = alt_url
@@ -70,7 +70,7 @@ search_backend = sql
 # Change API key HTTP header to something non-standard.
 apikey_header_name = X-Non-Standard-CKAN-API-Key
 
-ckan.plugins = stats 
+ckan.plugins = stats datastore dcat structured_data seriestiempoarexplorer gobar_theme googleanalytics
 
 # use <strong> so we can check that html is *not* escaped
 ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -26,10 +26,10 @@ ckan.datapusher.url = http://datapusher.ckan.org/
 ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
 
 ## Solr support
-solr_url = http://solr:8983/solr/ckan
+solr_url = http://127.0.0.1:8983/solr/ckan
 
 # Redis URL. Use a separate Redis database for testing.
-ckan.redis.url = redis://localhost:6379/1
+ckan.redis.url = redis://redis:6379/0
 
 ckan.auth.user_create_organizations = true
 ckan.auth.user_create_groups = true
@@ -51,10 +51,10 @@ ckan.site_title = CKAN
 ckan.site_logo = /images/ckan_logo_fullname_long.png
 ckan.site_description =
 package_form = standard
-licenses_group_url =
+licenses_group_url = file:///var/lib/ckan/theme_config/licenses.json
 # pyamqplib or queue
 carrot_messaging_library = queue
-ckan.site_url = http://example.com
+ckan.site_url = http://test.ckan.net
 package_new_return_url = http://localhost/dataset/<NAME>?test=new
 package_edit_return_url = http://localhost/dataset/<NAME>?test=edit
 ckan.extra_resource_fields = alt_url
@@ -70,7 +70,7 @@ search_backend = sql
 # Change API key HTTP header to something non-standard.
 apikey_header_name = X-Non-Standard-CKAN-API-Key
 
-ckan.plugins = stats datastore dcat structured_data seriestiempoarexplorer gobar_theme googleanalytics
+ckan.plugins = stats 
 
 # use <strong> so we can check that html is *not* escaped
 ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -51,7 +51,7 @@ ckan.site_title = CKAN
 ckan.site_logo = /images/ckan_logo_fullname_long.png
 ckan.site_description =
 package_form = standard
-licenses_group_url = need_some_text
+licenses_group_url = file_path_for_licenses_json
 # pyamqplib or queue
 carrot_messaging_library = queue
 ckan.site_url = http://example.com

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -51,7 +51,7 @@ ckan.site_title = CKAN
 ckan.site_logo = /images/ckan_logo_fullname_long.png
 ckan.site_description =
 package_form = standard
-licenses_group_url = file:///var/lib/ckan/theme_config/licenses.json
+licenses_group_url =
 # pyamqplib or queue
 carrot_messaging_library = queue
 ckan.site_url = http://test.ckan.net

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -30,7 +30,7 @@ class TestLicenseHelpers(TestHelpers):
         response = urllib2.urlopen(license_url)
         response_body = response.read()
         license_data = json.loads(response_body)
-        self.licenses = [license.License(entity) for entity in license_data.values()]
+        self.licenses = [license.License(entity) for entity in license_data]
 
     @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
     def __init__(self):

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -32,9 +32,9 @@ class TestLicenseHelpers(TestHelpers):
         license_data = json.loads(response_body)
         self.licenses = [license.License(entity) for entity in license_data]
 
-    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
-    def setup(self):
-        super(TestLicenseHelpers, self).setup()
+    @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
+    def __init__(self):
+        super(TestLicenseHelpers, self).__init__()
         self.licenses = gobar_helpers.license_options()
 
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -30,7 +30,8 @@ class TestLicenseHelpers(TestHelpers):
         response = urllib2.urlopen(license_url)
         response_body = response.read()
         license_data = json.loads(response_body)
-        license.LicenseRegister._create_license_list(license_data, '')
+        license_register = license.LicenseRegister()
+        license_register._create_license_list(license_data, '')
 
     @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
     def __init__(self):

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -38,8 +38,7 @@ class TestLicenseHelpers(TestHelpers):
                 "url": "https://opendefinition.org/licenses/odc-odbl"
             }
         ]
-        licenses = [license.License(entity) for entity in licenses_json]
-        self.licenses = gobar_helpers.license_options(licenses)
+        self.licenses = [license.License(entity) for entity in licenses_json]
 
     @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -32,9 +32,9 @@ class TestLicenseHelpers(TestHelpers):
         license_data = json.loads(response_body)
         self.licenses = [license.License(entity) for entity in license_data]
 
-    @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
-    def __init__(self):
-        super(TestLicenseHelpers, self).__init__()
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def setup(self):
+        super(TestLicenseHelpers, self).setup()
         self.licenses = gobar_helpers.license_options()
 
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -38,13 +38,13 @@ class TestLicenseHelpers(TestHelpers):
                 "url": "https://opendefinition.org/licenses/odc-odbl"
             }
         ]
-        licenses_register = license.LicenseRegister()
-        self.licenses = gobar_helpers.license_options(licenses_register._create_license_list(licenses_json))
+        licenses = [license.License(entity) for entity in licenses_json]
+        self.licenses = gobar_helpers.license_options(licenses)
 
     @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
-    def test_license_options_returns_14_licenses(self):
-        nt.assert_equals(len(self.licenses), 14)
+    def test_license_options_returns_2_licenses(self):
+        nt.assert_equals(len(self.licenses), 2)
 
     @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
@@ -59,10 +59,10 @@ class TestLicenseHelpers(TestHelpers):
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     def test_legacy_id_search_returns_correct_license(self):
         license = gobar_helpers.get_license('odc-pddl')
-        nt.assert_equals(license.title, 'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
+        nt.assert_equals(license.title, u'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
 
     @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     def test_license_title_search_returns_correct_title(self):
         nt.assert_equals(gobar_helpers.get_license_title('odc-pddl'),
-                         'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
+                         u'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -1,5 +1,9 @@
+# encoding: utf-8
+
+import os
+import json
+import urllib2
 from mock import patch
-from mockredis import mock_strict_redis_client
 import ckan.tests.factories as factories
 import nose.tools as nt
 from ckanext.gobar_theme.tests import TestAndino
@@ -10,11 +14,7 @@ from ckan.model import license
 
 class TestHelpers(TestAndino.TestAndino):
 
-    def __init__(self):
-        super(TestHelpers, self).__init__()
-
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
-    @patch('redis.StrictRedis', mock_strict_redis_client)
     def setup(self):
         super(TestHelpers, self).setup()
         self.admin = factories.Sysadmin()
@@ -22,31 +22,28 @@ class TestHelpers(TestAndino.TestAndino):
 
 class TestLicenseHelpers(TestHelpers):
 
+    def load_licenses(self, url):
+        # No usamos la URL que nos llega por parámetro porque queremos hardcodear el path del JSON
+        script_dir = os.path.dirname(__file__)
+        relative_path = 'tests_config/licenses.json'
+        license_url = "file://{}".format(os.path.join(script_dir, relative_path))
+        response = urllib2.urlopen(license_url)
+        response_body = response.read()
+        license_data = json.loads(response_body)
+        license.LicenseRegister._create_license_list(license_data, '')
+
+    @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
     def __init__(self):
         super(TestLicenseHelpers, self).__init__()
-        licenses_json = [
-            {
-                "id": "PDDL-1.0",
-                "legacy_ids": ["ODC-PDDL-1.0", "odc-pddl"],
-                "title": "Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)",
-                "url": "https://opendefinition.org/licenses/odc-pddl"
-            },
-            {
-                "id": "ODbL-1.0",
-                "legacy_ids": ["odc-odbl"],
-                "title": "Open Data Commons Open Database License 1.0 (ODbL)",
-                "url": "https://opendefinition.org/licenses/odc-odbl"
-            }
-        ]
-        self.licenses = [license.License(entity) for entity in licenses_json]
+        self.licenses = gobar_helpers.license_options()
 
-    @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
-    def test_license_options_returns_2_licenses(self):
-        nt.assert_equals(len(self.licenses), 2)
+    @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
+    def test_license_options_returns_1_licenses(self):
+        nt.assert_equals(len(self.licenses), 14)
 
-    @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
     def test_legacy_license_ids_are_detected(self):
         pddl_license = None
         for license in self.licenses:
@@ -54,14 +51,14 @@ class TestLicenseHelpers(TestHelpers):
                 pddl_license = license
         nt.assert_true(gobar_helpers.id_belongs_to_license('odc-pddl', pddl_license))
 
-    @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
     def test_legacy_id_search_returns_correct_license(self):
         license = gobar_helpers.get_license('odc-pddl')
         nt.assert_equals(license.title, u'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
 
-    @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
     def test_license_title_search_returns_correct_title(self):
         nt.assert_equals(gobar_helpers.get_license_title('odc-pddl'),
                          u'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -30,8 +30,7 @@ class TestLicenseHelpers(TestHelpers):
         response = urllib2.urlopen(license_url)
         response_body = response.read()
         license_data = json.loads(response_body)
-        license_register = license.LicenseRegister()
-        license_register._create_license_list(license_data, '')
+        self.licenses = [license.License(entity) for entity in license_data.values()]
 
     @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
     def __init__(self):
@@ -40,7 +39,7 @@ class TestLicenseHelpers(TestHelpers):
 
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     @patch('ckan.model.license.LicenseRegister.load_licenses', load_licenses)
-    def test_license_options_returns_1_licenses(self):
+    def test_license_options_returns_14_licenses(self):
         nt.assert_equals(len(self.licenses), 14)
 
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -5,6 +5,7 @@ import nose.tools as nt
 from ckanext.gobar_theme.tests import TestAndino
 import ckanext.gobar_theme.helpers as gobar_helpers
 from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
+from ckan.model import license
 
 
 class TestHelpers(TestAndino.TestAndino):
@@ -23,7 +24,22 @@ class TestLicenseHelpers(TestHelpers):
 
     def __init__(self):
         super(TestLicenseHelpers, self).__init__()
-        self.licenses = gobar_helpers.license_options()
+        licenses_json = [
+            {
+                "id": "PDDL-1.0",
+                "legacy_ids": ["ODC-PDDL-1.0", "odc-pddl"],
+                "title": "Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)",
+                "url": "https://opendefinition.org/licenses/odc-pddl"
+            },
+            {
+                "id": "ODbL-1.0",
+                "legacy_ids": ["odc-odbl"],
+                "title": "Open Data Commons Open Database License 1.0 (ODbL)",
+                "url": "https://opendefinition.org/licenses/odc-odbl"
+            }
+        ]
+        licenses_register = license.LicenseRegister()
+        self.licenses = gobar_helpers.license_options(licenses_register._create_license_list(licenses_json))
 
     @patch('redis.StrictRedis', mock_strict_redis_client)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -1,0 +1,52 @@
+from mock import patch
+from mockredis import mock_strict_redis_client
+import ckan.tests.factories as factories
+import nose.tools as nt
+from ckanext.gobar_theme.tests import TestAndino
+import ckanext.gobar_theme.helpers as gobar_helpers
+from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
+
+
+class TestHelpers(TestAndino.TestAndino):
+
+    def __init__(self):
+        super(TestHelpers, self).__init__()
+
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    def setup(self):
+        super(TestHelpers, self).setup()
+        self.admin = factories.Sysadmin()
+
+
+class TestLicenseHelpers(TestHelpers):
+
+    def __init__(self):
+        super(TestLicenseHelpers, self).__init__()
+        self.licenses = gobar_helpers.license_options()
+
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def test_license_options_returns_14_licenses(self):
+        nt.assert_equals(len(self.licenses), 14)
+
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def test_legacy_license_ids_are_detected(self):
+        pddl_license = None
+        for license in self.licenses:
+            if license.id == 'PDDL-1.0':
+                pddl_license = license
+        nt.assert_true(gobar_helpers.id_belongs_to_license('odc-pddl', pddl_license))
+
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def test_legacy_id_search_returns_correct_license(self):
+        license = gobar_helpers.get_license('odc-pddl')
+        nt.assert_equals(license.title, 'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
+
+    @patch('redis.StrictRedis', mock_strict_redis_client)
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    def test_license_title_search_returns_correct_title(self):
+        nt.assert_equals(gobar_helpers.get_license_title('odc-pddl'),
+                         'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')


### PR DESCRIPTION
* Creo un archivo JSON que contiene el conjunto de licencias de Andino.
* Actualizo los templates para los formularios de la metadata del portal, datasets y recursos.
* Creo tests para los helpers creados/modificados.

## Cómo probar la solución

1. Levantar una instancia de Andino normal
1. Se puede utilizar una licencia en cualquiera (o varios) de las siguientes funcionalidades:
  a. Metadata del portal:
    * Ir a la pantalla de Configuración -> Metadatos del portal
    * Seleccionar una licencia que utilice un id que, dentro del JSON nuevo, aparezca como `legacy_id`
  b. Dataset
    * Crear un dataset con una licencia usando el criterio anterior
  c. Recurso
    * Crear un recurso con una licencia usando el mismo criterio anterior
1. Actualizar Andino usando el branch correspondiente al PR
1. Visitar alguna de las licencias guardadas y, en base al JSON, comprobar que se esté utilizando la licencia correspondiente al id utilizado.

Closes #383.
Modificar el Dockerfile de portal-andino para que el mismo utilice la versión 0.10.24 de portal-base, ya que es parte de la solución del issue.