### PR TITLE
Botón de PUBLICAR en el formulario de datasets si éste es un borrador

### DIFF
--- a/ckanext/gobar_theme/package_controller.py
+++ b/ckanext/gobar_theme/package_controller.py
@@ -311,7 +311,10 @@ class GobArPackageController(PackageController):
                     data_dict['id'] = data_dict['pkg_name']
                     del data_dict['pkg_name']
                     # don't change the dataset state
-                    data_dict['state'] = 'draft'
+                    if data_dict.get('save', '') == u'go-metadata':
+                        data_dict['state'] = 'active'
+                    else:
+                        data_dict['state'] = 'draft'
                     # this is actually an edit not a save
                     pkg_dict = get_action('package_update')(context, data_dict)
 

--- a/ckanext/gobar_theme/templates/package/snippets/package_form.html
+++ b/ckanext/gobar_theme/templates/package/snippets/package_form.html
@@ -22,6 +22,14 @@
 
     {% snippet 'package/snippets/package_metadata_fields.html', data=data, errors=errors %}
 
+    {% if data.state %}
+        {% if data.state == 'draft' %}
+           {% set show_publish_button = true %}
+        {% else %}
+            {% set show_publish_button = false %}
+        {% endif %}
+    {% endif %}
+
     <div class="form-actions">
         {% block delete_button %}
             {% if h.check_access('package_delete', {'id': data.id}) and not data.state == 'deleted' %}
@@ -35,6 +43,11 @@
                 GUARDAR BORRADOR
             </button>
         {% endblock %}
+            {% if show_publish_button %}
+                <button id="publish-button" class="btn btn-green" name="save" value="go-metadata" type="submit">
+                    PUBLICAR
+                </button>
+            {% endif %}
         {% block save_button %}
             <button class="btn btn-blue" type="submit" name="save" value="continue">
                 {% block save_button_text -%}


### PR DESCRIPTION
## Cómo probar la solución

1. Levantar una instancia de Andino usando este branch
1. Crear un dataset borrador (usando el botón _GUARDAR COMO BORRADOR_)
1. Entrar al formulario de edición del dataset y publicarlo
1. Asegurarse de que el dataset ya no esté como borrador (no se puede volver a publicar, porque ya está publicado)

Closes #398.