### PR TITLE
Creación automática de vistas default

### DIFF
--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -301,6 +301,7 @@ class GobArConfigController(base.BaseController):
         return base.render('config/config_15_google_dataset_search.html')
 
     def edit_datapusher_commands(self):
+        from ckanext.gobar_theme.helpers import get_config_file_path, get_paster_path
         self._authorize()
         if request.method == 'POST':
             from ckanext.gobar_theme.helpers import create_or_update_cron_job
@@ -317,7 +318,8 @@ class GobArConfigController(base.BaseController):
             # Creamos el cron job, reemplazando el anterior si ya existía
             command = '{0} datapusher submit_all {1} && ' \
                       '{0} views create {1}'\
-                .format('/usr/lib/ckan/default/bin/paster --plugin=ckan', '-y -c /etc/ckan/default/production.ini')
+                .format('{} --plugin=ckan'.format(get_paster_path()),
+                        '-y -c {}'.format(get_config_file_path()))
             comment = 'datapusher - submit_all'
             create_or_update_cron_job(command, hour=schedule_hour, minute=schedule_minute, comment=comment)
 

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -315,8 +315,9 @@ class GobArConfigController(base.BaseController):
             self._set_config(config_dict)
 
             # Creamos el cron job, reemplazando el anterior si ya existía
-            command = '/usr/lib/ckan/default/bin/paster --plugin=ckan datapusher submit_all -y -c  ' \
-                      '/etc/ckan/default/production.ini'
+            command = '{0} datapusher submit_all {1} && ' \
+                      '{0} views create {1}'\
+                .format('/usr/lib/ckan/default/bin/paster --plugin=ckan', '-y -c /etc/ckan/default/production.ini')
             comment = 'datapusher - submit_all'
             create_or_update_cron_job(command, hour=schedule_hour, minute=schedule_minute, comment=comment)
 

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -25,6 +25,14 @@ import csv
 logger = logging.getLogger(__name__)
 
 
+def get_config_file_path():
+    return "{}/production.ini".format(subprocess.check_output("echo $CONFIG_FILE").strip())
+
+
+def get_paster_path():
+    return "{}/bin/paster".format(subprocess.check_output("echo $CKAN_HOME").strip())
+
+
 def _get_organizations_objs(organizations_branch, depth=0):
     organizations = []
     for tree_obj in organizations_branch:

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -6,7 +6,6 @@ import ckan.lib.search as search
 import ckan.logic as logic
 import ckan.model as model
 import moment
-import subprocess
 from ckan.common import request, c, g, _
 import ckan.lib.formatters as formatters
 import subprocess
@@ -26,11 +25,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_config_file_path():
-    return "{}/production.ini".format(subprocess.check_output("echo $CONFIG_FILE").strip())
+    return "{}/production.ini".format(subprocess.check_output("echo $CKAN_DEFAULT", shell=True).strip())
 
 
 def get_paster_path():
-    return "{}/bin/paster".format(subprocess.check_output("echo $CKAN_HOME").strip())
+    return "{}/bin/paster".format(subprocess.check_output("echo $CKAN_HOME", shell=True).strip())
 
 
 def _get_organizations_objs(organizations_branch, depth=0):

--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -10378,6 +10378,7 @@ form#datapusher > table.date-picker.datapusher {
   margin: 0;
 }
 
-p.datapusher-text {
-  margin: 0;
+#template-config-container #template-config p.datapusher-text {
+  margin-bottom: 5px;
 }
+

--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -10370,9 +10370,14 @@ label[for="accessURL-upload-url"] {
 
 form#datapusher > table.date-picker.datapusher {
   width: 20%;
+  margin: 10px 0;
 }
 
 #template-config-container #template-config select.datapusher {
   width: 40%;
+  margin: 0;
+}
+
+p.datapusher-text {
   margin: 0;
 }

--- a/ckanext/gobar_theme/templates/config/config_18_datapusher_commands.html
+++ b/ckanext/gobar_theme/templates/config/config_18_datapusher_commands.html
@@ -31,8 +31,8 @@
                 </div>
             </td>
         </table>
-        <p>La subida de recursos se ejecutará todos los días en el horario establecido, según el <a href="http://manpages.ubuntu.com/manpages/bionic/man3/DateTime::TimeZone::Catalog.3pm.html">timezone</a> especificado en la instalación (Buenos Aires por default).</p>
-        <p>Adicionalmente, para los recursos subidos al Datastore que no posean vistas para la previsualización, se creará una.</p>
+        <p class="datapusher-text">La subida de recursos se ejecutará todos los días en el horario establecido, según el <a href="http://manpages.ubuntu.com/manpages/bionic/man3/DateTime::TimeZone::Catalog.3pm.html">timezone</a> especificado en la instalación (Buenos Aires por default).</p>
+        <p class="datapusher-text">Adicionalmente, para los recursos subidos al Datastore que no posean vistas para la previsualización, se creará una.</p>
 
         <div class="submit-container">
             <button class="submit-button" type="submit" name="save">GUARDAR</button>

--- a/ckanext/gobar_theme/templates/config/config_18_datapusher_commands.html
+++ b/ckanext/gobar_theme/templates/config/config_18_datapusher_commands.html
@@ -32,6 +32,7 @@
             </td>
         </table>
         <p>La subida de recursos se ejecutará todos los días en el horario establecido, según el <a href="http://manpages.ubuntu.com/manpages/bionic/man3/DateTime::TimeZone::Catalog.3pm.html">timezone</a> especificado en la instalación (Buenos Aires por default).</p>
+        <p>Adicionalmente, para los recursos subidos al Datastore que no posean vistas para la previsualización, se creará una.</p>
 
         <div class="submit-container">
             <button class="submit-button" type="submit" name="save">GUARDAR</button>


### PR DESCRIPTION
Teniendo en cuenta que la subida de recursos al Datastore no necesariamente se ve siempre acompañada por la creación de una vista que permita la previsualización de cada recurso, se agregó al cronjob del comando de Datapusher existente la ejecución de un comando de CKAN que toma todos los recursos e intenta crearles una vista.

## Cómo probar la solución

1. Levantar una instancia de Andino usando este branch
1. Crear un recurso subiéndole un archivo de tipo CSV o XLSX
1. Eliminar la vista creada automáticamente en el formulario de edición de un recurso
1. Ir a la configuración de comandos de Datapusher, seleccionar el siguiente minuto para poder probar rápidamente la ejecución del comando, y guardar
1. Dentro del container de Andino, ejecutar `crontab -u www-data -l` y asegurarse de que exista el cronjob `/usr/lib/ckan/default/bin/paster --plugin=ckan datapusher submit_all -y -c /etc/ckan/default/production.ini && /usr/lib/ckan/default/bin/paster --plugin=ckan views create -y -c /etc/ckan/default/production.ini # datapusher - submit_all`
1. Aproximadamente 10 segundos después de que llegue el momento indicado en la configuración del comando, entrar a la página de visualización del recurso creado y asegurarse de que la previsualización esté presente

Closes #396.