### PR TITLE
Fix pagina datasets filtrando por organizacion

### DIFF
--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -247,41 +247,6 @@ def all_descendants(organization_list):
     return descendants
 
 
-def organization_filters():
-    top_organizations = {}
-    ancestors_relations = {}
-    tree = organization_tree()
-    for top_organization in tree:
-        top_organization['count'] = 0
-        top_organizations[top_organization['name']] = top_organization
-        ancestors_relations[top_organization['name']] = top_organization['name']
-        if 'children' in top_organization and len(top_organization['children']) > 0:
-            children = all_descendants(top_organization['children'])
-            for child_name in children:
-                ancestors_relations[child_name] = top_organization['name']
-
-    for organization in ckan_helpers.get_facet_items_dict('organization'):
-        top_parent_name = ancestors_relations[organization['name']]
-        if top_parent_name in top_organizations:
-            top_organizations[top_parent_name]['count'] += organization['count']
-    if ckan_helpers.get_request_param('organization') in top_organizations:
-        top_organizations[ckan_helpers.get_request_param('organization')]['active'] = True
-
-    top_organizations_with_results = [organization for organization in top_organizations.values() if
-                                      organization['count'] > 0]
-    sorted_organizations = sorted(top_organizations_with_results, key=lambda item: item['count'], reverse=True)
-
-    org_limit = request.params.get('_organization_limit', g.facets_default_number)
-    if org_limit != '':
-        limit = int(org_limit)
-    else:
-        limit = None
-    c.search_facets_limits['organization'] = limit
-    if limit is not None and limit > 0:
-        return sorted_organizations[:limit]
-    return sorted_organizations
-
-
 def get_theme_config(path=None, default=None):
     return GobArConfigController.get_theme_config(path, default)
 

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -86,7 +86,6 @@ def organizations_basic_info():
 
     # Traemos las organizaciones
     organizations = get_organizations_tree()
-    import pdb; pdb.set_trace()
     ckan_organizations_info = {item['name']: item for item in get_facet_items_dict('organization')}
 
     # Realizamos una query para conseguir las organizaciones que tienen datasets, y la cantidad de éstos

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -86,7 +86,7 @@ def organizations_basic_info():
 
     # Traemos las organizaciones
     organizations = get_organizations_tree()
-    ckan_organizations_info = {item['name']: item for item in get_facet_items_dict('organization')}
+    ckan_organizations_info = {item['name']: item for item in ckan_helpers.get_facet_items_dict('organization')}
 
     # Realizamos una query para conseguir las organizaciones que tienen datasets, y la cantidad de éstos
     query = search.PackageSearchQuery()
@@ -145,7 +145,7 @@ def fetch_groups():
 
 def get_faceted_groups(items_limit=None):
     groups = fetch_groups()
-    facets = get_facet_items_dict(facet='groups', limit=items_limit)
+    facets = ckan_helpers.get_facet_items_dict(facet='groups', limit=items_limit)
     facets_by_name = {}
     for facet in facets:
         facets_by_name[facet['name']] = facet
@@ -158,12 +158,6 @@ def get_faceted_groups(items_limit=None):
             group['facet_active'] = False
             group['facet_count'] = 0
     return groups
-
-
-def get_facet_items_dict(facet, limit=None, exclude_active=False):
-    # CKAN impone un límite de 10 para los temas. Puedo tener más de 10, por lo que no podría clickear el resto.
-    c.search_facets_limits['groups'] = None
-    return ckan_helpers.get_facet_items_dict(facet, limit, exclude_active)
 
 
 def remove_url_param(key, value=None, replace=None, controller=None,

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -61,48 +61,47 @@ def organizations_basic_info():
         current_organization['title'] = organization.pop('title')
         current_organization['depth'] = depth  # si depth == 0, la organización no es hija de otra
         current_organization['own_package_count'] = organizations_that_have_packages.pop(organization_id, 0)
-        total_package_count = 0
-        group_tree_children = organization.pop('children')
+        own_available_package_count = ckan_organizations_info.pop(current_organization['name'], {}).get('count', 0)
+        children_data_dict = generate_children_data(organization.pop('children'), depth)
+        current_organization['children'] = children_data_dict['dict_children']
+        current_organization['total_package_count'] = children_data_dict['current_total_package_count'] \
+                                                      + current_organization['own_package_count']
+        current_organization['available_package_count'] = children_data_dict['current_available_package_count'] + \
+                                                          own_available_package_count
+        current_organization['active'] = current_organization['name'] == organization_in_request
+        current_organization['display'] = not organization_in_request or current_organization['active']
+        return current_organization
+
+    def generate_children_data(group_tree_children, depth):
         dict_children = []
+        current_available_package_count = 0
+        current_total_package_count = 0
         for child in group_tree_children:
             converted_child = convert_organization_to_dict(child, depth+1)
             dict_children.append(converted_child)
-            total_package_count += converted_child.get('total_package_count', 0)
-        current_organization['children'] = dict_children
-        current_organization['total_package_count'] = total_package_count + current_organization['own_package_count']
-        return current_organization
+            current_available_package_count += converted_child.get('available_package_count', 0)
+            current_total_package_count += converted_child.get('total_package_count', 0)
+        return {'dict_children': dict_children, 'current_available_package_count': current_available_package_count,
+                'current_total_package_count': current_total_package_count}
 
     # Traemos las organizaciones
     organizations = logic.get_action('group_tree')({}, {'type': 'organization'})
+    ckan_organizations_info = {item['name']: item for item in ckan_helpers.get_facet_items_dict('organization')}
 
     # Realizamos una query para conseguir las organizaciones que tienen datasets, y la cantidad de éstos
     query = search.PackageSearchQuery()
-    q = {'q': '+capacity:public',
-         'fl': 'groups', 'facet.field': ['groups', 'owner_org'],
-         'facet.limit': -1, 'rows': 1}
+    q = {'q': '+capacity:public', 'fl': 'groups', 'facet.field': ['groups', 'owner_org'], 'facet.limit': -1, 'rows': 1}
     query.run(q)
     organizations_that_have_packages = query.facets.get('owner_org')
 
     # Transformamos cada organización en un dict para facilitar su uso, y agregamos información requerida
     organizations_data = []
+    organization_in_request = ckan_helpers.get_request_param('organization')
     for organization in organizations:
         current_organization = convert_organization_to_dict(organization, 0)
         organizations_data.append(current_organization)
 
     return organizations_data
-
-
-def update_organizations_package_count(organizations):
-    updated_organizations_list = []
-    ckan_organizations_info = ckan_helpers.get_facet_items_dict('organization')
-    ckan_organizations_info = {item['name']: item for item in ckan_organizations_info}
-    for organization in organizations:
-        equivalent_organization = ckan_organizations_info.pop(organization['name'], None)
-        if equivalent_organization:
-            organization['total_package_count'] = equivalent_organization['count']
-            organization['active'] = equivalent_organization['active']
-            updated_organizations_list.append(organization)
-    return updated_organizations_list
 
 
 def organization_tree():

--- a/ckanext/gobar_theme/helpers.py
+++ b/ckanext/gobar_theme/helpers.py
@@ -85,8 +85,9 @@ def organizations_basic_info():
                 'current_total_package_count': current_total_package_count}
 
     # Traemos las organizaciones
-    organizations = logic.get_action('group_tree')({}, {'type': 'organization'})
-    ckan_organizations_info = {item['name']: item for item in ckan_helpers.get_facet_items_dict('organization')}
+    organizations = get_organizations_tree()
+    import pdb; pdb.set_trace()
+    ckan_organizations_info = {item['name']: item for item in get_facet_items_dict('organization')}
 
     # Realizamos una query para conseguir las organizaciones que tienen datasets, y la cantidad de éstos
     query = search.PackageSearchQuery()
@@ -102,6 +103,10 @@ def organizations_basic_info():
         organizations_data.append(current_organization)
 
     return organizations_data
+
+
+def get_organizations_tree():
+    return logic.get_action('group_tree')({}, {'type': 'organization'})
 
 
 def organization_tree():
@@ -157,8 +162,6 @@ def get_faceted_groups(items_limit=None):
 
 
 def get_facet_items_dict(facet, limit=None, exclude_active=False):
-    if facet == 'organization':
-        return organization_filters()
     # CKAN impone un límite de 10 para los temas. Puedo tener más de 10, por lo que no podría clickear el resto.
     c.search_facets_limits['groups'] = None
     return ckan_helpers.get_facet_items_dict(facet, limit, exclude_active)

--- a/ckanext/gobar_theme/lib/datajson_actions.py
+++ b/ckanext/gobar_theme/lib/datajson_actions.py
@@ -245,7 +245,8 @@ def get_ckan_datasets(org=None, with_private=True):
             'start': n * (page - 1),
         }
 
-        query = logic.get_action('package_search')({}, search_data_dict)
+        # query = logic.get_action('package_search')({}, search_data_dict)
+        query = logic.action.get.package_search({}, search_data_dict)
         if len(query['results']):
             dataset_list.extend(query['results'])
             page += 1

--- a/ckanext/gobar_theme/lib/datajson_actions.py
+++ b/ckanext/gobar_theme/lib/datajson_actions.py
@@ -245,7 +245,6 @@ def get_ckan_datasets(org=None, with_private=True):
             'start': n * (page - 1),
         }
 
-        # query = logic.get_action('package_search')({}, search_data_dict)
         query = logic.action.get.package_search({}, search_data_dict)
         if len(query['results']):
             dataset_list.extend(query['results'])

--- a/ckanext/gobar_theme/lib/datajson_actions.py
+++ b/ckanext/gobar_theme/lib/datajson_actions.py
@@ -245,7 +245,7 @@ def get_ckan_datasets(org=None, with_private=True):
             'start': n * (page - 1),
         }
 
-        query = p.toolkit.get_action('package_search')({}, search_data_dict)
+        query = logic.get_action('package_search')({}, search_data_dict)
         if len(query['results']):
             dataset_list.extend(query['results'])
             page += 1

--- a/ckanext/gobar_theme/package_controller.py
+++ b/ckanext/gobar_theme/package_controller.py
@@ -60,9 +60,6 @@ def custom_organization_filter(organization_name):
 
 class GobArPackageController(PackageController):
 
-    def get_package_search(self):
-        return get_action('package_search')
-
     def __generate_spatial_extra_field(self, data_dict):
         extras = data_dict['extras']
 
@@ -204,10 +201,7 @@ class GobArPackageController(PackageController):
                 'extras': search_extras
             }
 
-            # package_search = self.get_package_search()
-            # query = package_search(context, data_dict)
             query = logic.action.get.package_search(context, data_dict)
-            # query = get_action('package_search')(context, data_dict)
             c.sort_by_selected = query['sort']
 
             c.page = h.Page(

--- a/ckanext/gobar_theme/package_controller.py
+++ b/ckanext/gobar_theme/package_controller.py
@@ -59,7 +59,10 @@ def custom_organization_filter(organization_name):
 
 
 class GobArPackageController(PackageController):
-    
+
+    def get_package_search(self):
+        return get_action('package_search')
+
     def __generate_spatial_extra_field(self, data_dict):
         extras = data_dict['extras']
 
@@ -201,7 +204,10 @@ class GobArPackageController(PackageController):
                 'extras': search_extras
             }
 
-            query = get_action('package_search')(context, data_dict)
+            # package_search = self.get_package_search()
+            # query = package_search(context, data_dict)
+            query = logic.action.get.package_search(context, data_dict)
+            # query = get_action('package_search')(context, data_dict)
             c.sort_by_selected = query['sort']
 
             c.page = h.Page(

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -65,7 +65,6 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'cut_img_path': gobar_helpers.cut_img_path,
             'organizations_with_packages': gobar_helpers.organizations_with_packages,
             'get_pkg_extra': gobar_helpers.get_pkg_extra,
-            'get_facet_items_dict': gobar_helpers.get_facet_items_dict,
             'get_theme_config': gobar_helpers.get_theme_config,
             'url_join': gobar_helpers.url_join,
             'json_loads': gobar_helpers.json_loads,

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -105,7 +105,6 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_default_series_api_url': gobar_helpers.get_default_series_api_url,
             'create_or_update_cron_job': gobar_helpers.create_or_update_cron_job,
             'get_current_terminal_username': gobar_helpers.get_current_terminal_username,
-            'update_organizations_package_count': gobar_helpers.update_organizations_package_count,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/plugin.py
+++ b/ckanext/gobar_theme/plugin.py
@@ -105,6 +105,7 @@ class Gobar_ThemePlugin(plugins.SingletonPlugin):
             'get_default_series_api_url': gobar_helpers.get_default_series_api_url,
             'create_or_update_cron_job': gobar_helpers.create_or_update_cron_job,
             'get_current_terminal_username': gobar_helpers.get_current_terminal_username,
+            'get_organizations_tree': gobar_helpers.get_organizations_tree,
         }
 
     def _prepare_data_for_storage_outside_datajson(self, arguments_list_to_store, entity_dict, object_type):

--- a/ckanext/gobar_theme/templates/package/snippets/search_facets_organizations.html
+++ b/ckanext/gobar_theme/templates/package/snippets/search_facets_organizations.html
@@ -1,17 +1,19 @@
-{% set items = h.update_organizations_package_count(h.organizations_basic_info()) %}
+{% set items = h.organizations_basic_info() %}
 <div class="search-filter invisible">
     <h2 class="filter-title">{{ title }}</h2>
     {% if items %}
         <ul class="filter-values">
             {% for item in items %}
-                {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
-                {% set count = item.total_package_count %}
-                <a href="{{ href }}">
-                    <li class="filter-value {% if item.active %} active{% endif %}">
-                        <span>{{ item.title }} {{ '(%d)' % count }}</span>
-                        <img class="close-filter" src="/img/close-filter.svg">
-                    </li>
-                </a>
+                {% if item.display and item.available_package_count %}
+                    {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
+                    {% set count = item.available_package_count %}
+                    <a href="{{ href }}">
+                        <li class="filter-value {% if item.active %} active{% endif %}">
+                            <span>{{ item.title }} {{ '(%d)' % count }}</span>
+                            <img class="close-filter" src="/img/close-filter.svg">
+                        </li>
+                    </a>
+                {% endif %}
             {% endfor %}
         </ul>
 

--- a/ckanext/gobar_theme/tests/TestAndino.py
+++ b/ckanext/gobar_theme/tests/TestAndino.py
@@ -5,7 +5,6 @@ import json
 import logging
 import tempfile
 import sqlalchemy
-from abc import ABCMeta, abstractmethod
 from routes import url_for
 import ckan
 import ckan.lib.search
@@ -31,7 +30,6 @@ class GobArConfigControllerForTest(GobArConfigController):
 @patch("ckan.logic.action.get.package_search", package_search)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestAndino(helpers.FunctionalTestBase):
-    __metaclass__ = ABCMeta
 
     def __init__(self):
         self.app = self._get_test_app()

--- a/ckanext/gobar_theme/tests/TestAndino.py
+++ b/ckanext/gobar_theme/tests/TestAndino.py
@@ -17,6 +17,7 @@ from ckanext.gobar_theme.lib.datajson_actions import CACHE_DIRECTORY
 from ckanext.gobar_theme.lib.datajson_actions import generate_new_cache_file
 from ckanext.gobar_theme.config_controller import GobArConfigController
 from mock import patch
+from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize, create_organization
 
 logger = logging.getLogger(__name__)
 submit_and_follow = helpers.submit_and_follow
@@ -27,19 +28,22 @@ class GobArConfigControllerForTest(GobArConfigController):
     CONFIG_PATH = CACHE_DIRECTORY + "test_settings.json"
 
 
+@patch("ckan.logic.action.get.package_search", package_search)
+@patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestAndino(helpers.FunctionalTestBase):
     __metaclass__ = ABCMeta
 
-    @abstractmethod
     def __init__(self):
         self.app = self._get_test_app()
         self.org = None
         self.TEST_CACHE_PATH = CACHE_DIRECTORY + "datajson_cache_backup.json"
 
+    @patch("ckan.logic.action.get.package_search", package_search)
+    @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     def setup(self):
         super(TestAndino, self).setup()
-        # self.org = factories.Organization()
+        self.org = create_organization(name='organizacion')
 
     @classmethod
     def setup_class(cls):

--- a/ckanext/gobar_theme/tests/TestAndino.py
+++ b/ckanext/gobar_theme/tests/TestAndino.py
@@ -16,7 +16,8 @@ from ckanext.gobar_theme.lib.datajson_actions import CACHE_DIRECTORY
 from ckanext.gobar_theme.lib.datajson_actions import generate_new_cache_file
 from ckanext.gobar_theme.config_controller import GobArConfigController
 from mock import patch
-from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize, create_organization
+from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize, create_organization, \
+    get_action
 
 logger = logging.getLogger(__name__)
 submit_and_follow = helpers.submit_and_follow
@@ -27,6 +28,7 @@ class GobArConfigControllerForTest(GobArConfigController):
     CONFIG_PATH = CACHE_DIRECTORY + "test_settings.json"
 
 
+@patch("ckan.logic.get_action", get_action)
 @patch("ckan.logic.action.get.package_search", package_search)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestAndino(helpers.FunctionalTestBase):

--- a/ckanext/gobar_theme/tests/TestAndino.py
+++ b/ckanext/gobar_theme/tests/TestAndino.py
@@ -39,7 +39,7 @@ class TestAndino(helpers.FunctionalTestBase):
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     def setup(self):
         super(TestAndino, self).setup()
-        self.org = factories.Organization()
+        # self.org = factories.Organization()
 
     @classmethod
     def setup_class(cls):

--- a/ckanext/gobar_theme/tests/TestAndino.py
+++ b/ckanext/gobar_theme/tests/TestAndino.py
@@ -116,10 +116,12 @@ class TestAndino(helpers.FunctionalTestBase):
     @patch('ckanext.gobar_theme.config_controller.GobArConfigController', GobArConfigControllerForTest)
     def create_package_with_one_resource_using_forms(self, dataset_name=u'package-with-one-resource',
                                                      resource_url=u'http://example.com/resource',
+                                                     data_dict={},
                                                      draft=False):
         env, response = self.get_page_response('/dataset/new')
         form = response.forms['dataset-edit']
         form['name'] = dataset_name
+        self.fill_form_using_data_dict(form, data_dict)
         response = submit_and_follow(self.app, form, env, 'save', 'continue')
 
         form = response.forms['resource-edit']
@@ -136,11 +138,7 @@ class TestAndino(helpers.FunctionalTestBase):
         env, response = self.get_page_response('/dataset/edit/{0}'.format(dataset_name))
         form = response.forms['dataset-edit']
         form['notes'] = u'New description'
-        for key, value in data_dict:
-            try:
-                form[key] = value
-            except KeyError:
-                logger.warning("Se está pasando un parámetro incorrecto en un test de edición de datasets.")
+        self.fill_form_using_data_dict(form, data_dict)
         button_value = 'go-metadata' if dataset_is_draft else 'continue'
         submit_and_follow(self.app, form, env, 'save', button_value)
         return model.Package.by_name(dataset_name)
@@ -152,6 +150,13 @@ class TestAndino(helpers.FunctionalTestBase):
         form = response.forms['confirm-dataset-delete-form']
         response = submit_and_follow(self.app, form, env, 'delete')
         return response
+
+    def fill_form_using_data_dict(self, form, data_dict):
+        for key, value in data_dict:
+            try:
+                form[key] = value
+            except KeyError:
+                logger.warning("Se está pasando un parámetro incorrecto en un test de edición de datasets.")
 
     # --- Resources --- #
 
@@ -200,7 +205,7 @@ class TestAndino(helpers.FunctionalTestBase):
 
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     @patch('ckanext.gobar_theme.config_controller.GobArConfigController', GobArConfigControllerForTest)
-    def edit_form_value(self, response, form_id=None, field_name=None, field_type='text', value=u'Campo modificado'):
+    def edit_form_value(self, response, form_id=None, field_name=None, field_type='text', value=u'Campo modificado'):  # TODO: borrar y usar la nueva función en su lugar
         admin = factories.Sysadmin()
         if form_id:
             form = response.forms[form_id]
@@ -211,6 +216,28 @@ class TestAndino(helpers.FunctionalTestBase):
             form[field_name].value = value
         elif field_type == 'checkbox':
             form[field_name].checked = value
+        env = {'REMOTE_USER': admin['name'].encode('ascii')}
+        try:
+            response = submit_and_follow(self.app, form, env, 'save', value="config-form")
+        except Exception:
+            # Trató de encolar una tarea
+            pass
+        return response
+
+    @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
+    @patch('ckanext.gobar_theme.config_controller.GobArConfigController', GobArConfigControllerForTest)
+    def edit_form_values(self, response, form_id=None, data_dict={}):
+        admin = factories.Sysadmin()
+        if form_id:
+            form = response.forms[form_id]
+        else:
+            # El form a buscar no tiene un id bajo el cual buscarlo
+            form = response.forms[0]
+        for element in data_dict:
+            if element.get('field_type') == 'text':
+                form[element.get('field_name')].value = element.get('value')  # TODO: mejorar sección antes de mergear
+            elif element.get('field_type') == 'checkbox':
+                form[element.get('field_name')].checked = element.get('value')
         env = {'REMOTE_USER': admin['name'].encode('ascii')}
         try:
             response = submit_and_follow(self.app, form, env, 'save', value="config-form")

--- a/ckanext/gobar_theme/tests/TestAndino.py
+++ b/ckanext/gobar_theme/tests/TestAndino.py
@@ -12,15 +12,12 @@ import ckan.model as model
 import ckan.logic as logic
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
-import pylons
-from pylons.util import ContextObj, PylonsContext
-
 from ckanext.gobar_theme.lib.datajson_actions import CACHE_DIRECTORY
 from ckanext.gobar_theme.lib.datajson_actions import generate_new_cache_file
 from ckanext.gobar_theme.config_controller import GobArConfigController
 from mock import patch
 from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize, create_organization, \
-    get_action, get_package_search
+    get_action
 
 logger = logging.getLogger(__name__)
 submit_and_follow = helpers.submit_and_follow
@@ -40,12 +37,6 @@ class TestAndino(helpers.FunctionalTestBase):
         self.app = self._get_test_app()
         self.org = None
         self.TEST_CACHE_PATH = CACHE_DIRECTORY + "datajson_cache_backup.json"
-        # c = ContextObj()
-        # py_obj = PylonsContext()
-        # py_obj.tmpl_context = c
-        # pylons.tmpl_context._push_object(c)
-        # from ckan import common
-        # common.c = c
 
     @patch("ckan.logic.action.get.package_search", package_search)
     @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
@@ -101,14 +92,6 @@ class TestAndino(helpers.FunctionalTestBase):
 
     # ------ Methods with factories ------ #
 
-    # @patch("ckan.logic.get_action", get_action)
-    # @patch("ckan.logic.action.get.package_search", package_search)
-    # @patch("ckanext.gobar_theme.package_controller.GobArPackageController.get_package_search", get_package_search)
-    from ckan.controllers.package import PackageController
-    class Prueba(PackageController):
-        def search(self):
-            return None
-    @patch("ckanext.gobar_theme.package_controller.GobArPackageController", Prueba)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     @patch('ckanext.gobar_theme.config_controller.GobArConfigController', GobArConfigControllerForTest)
     def get_page_response(self, url, admin_required=False):

--- a/ckanext/gobar_theme/tests/TestAndino.py
+++ b/ckanext/gobar_theme/tests/TestAndino.py
@@ -12,12 +12,15 @@ import ckan.model as model
 import ckan.logic as logic
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
+import pylons
+from pylons.util import ContextObj, PylonsContext
+
 from ckanext.gobar_theme.lib.datajson_actions import CACHE_DIRECTORY
 from ckanext.gobar_theme.lib.datajson_actions import generate_new_cache_file
 from ckanext.gobar_theme.config_controller import GobArConfigController
 from mock import patch
 from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize, create_organization, \
-    get_action
+    get_action, get_package_search
 
 logger = logging.getLogger(__name__)
 submit_and_follow = helpers.submit_and_follow
@@ -37,6 +40,12 @@ class TestAndino(helpers.FunctionalTestBase):
         self.app = self._get_test_app()
         self.org = None
         self.TEST_CACHE_PATH = CACHE_DIRECTORY + "datajson_cache_backup.json"
+        # c = ContextObj()
+        # py_obj = PylonsContext()
+        # py_obj.tmpl_context = c
+        # pylons.tmpl_context._push_object(c)
+        # from ckan import common
+        # common.c = c
 
     @patch("ckan.logic.action.get.package_search", package_search)
     @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
@@ -92,6 +101,14 @@ class TestAndino(helpers.FunctionalTestBase):
 
     # ------ Methods with factories ------ #
 
+    # @patch("ckan.logic.get_action", get_action)
+    # @patch("ckan.logic.action.get.package_search", package_search)
+    # @patch("ckanext.gobar_theme.package_controller.GobArPackageController.get_package_search", get_package_search)
+    from ckan.controllers.package import PackageController
+    class Prueba(PackageController):
+        def search(self):
+            return None
+    @patch("ckanext.gobar_theme.package_controller.GobArPackageController", Prueba)
     @patch('ckanext.gobar_theme.helpers.GobArConfigController', GobArConfigControllerForTest)
     @patch('ckanext.gobar_theme.config_controller.GobArConfigController', GobArConfigControllerForTest)
     def get_page_response(self, url, admin_required=False):

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -70,7 +70,7 @@ search_backend = sql
 # Change API key HTTP header to something non-standard.
 apikey_header_name = X-Non-Standard-CKAN-API-Key
 
-ckan.plugins = stats datastore dcat structured_data seriestiempoarexplorer gobar_theme googleanalytics
+ckan.plugins = stats hierarchy_display hierarchy_form datastore dcat structured_data seriestiempoarexplorer gobar_theme googleanalytics
 
 # use <strong> so we can check that html is *not* escaped
 ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">

--- a/ckanext/gobar_theme/tests/tests_datajson.py
+++ b/ckanext/gobar_theme/tests/tests_datajson.py
@@ -7,7 +7,7 @@ from ckanext.gobar_theme.lib.datajson_actions import generate_new_cache_file, fi
     get_datasets_with_resources, get_ckan_datasets, CACHE_DIRECTORY
 from ckanext.gobar_theme.tests import TestAndino as TestAndino
 from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
-from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize
+from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize, get_action
 import ckan.model as model
 import tempfile
 from ckan.tests import helpers as helpers
@@ -17,6 +17,7 @@ from mock import patch
 from mockredis import mock_strict_redis_client
 
 
+@patch("ckan.controllers.package.get_action", get_action)
 @patch("ckan.controllers.package.get_action", package_search)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestDatajsonGeneration(TestAndino.TestAndino):

--- a/ckanext/gobar_theme/tests/tests_datajson.py
+++ b/ckanext/gobar_theme/tests/tests_datajson.py
@@ -17,8 +17,8 @@ from mock import patch
 from mockredis import mock_strict_redis_client
 
 
-@patch("ckan.controllers.package.get_action", get_action)
-@patch("ckan.controllers.package.get_action", package_search)
+@patch("ckan.logic.get_action", get_action)
+@patch("ckan.logic.action.get.package_search", package_search)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestDatajsonGeneration(TestAndino.TestAndino):
 

--- a/ckanext/gobar_theme/tests/tests_datajson.py
+++ b/ckanext/gobar_theme/tests/tests_datajson.py
@@ -17,7 +17,7 @@ from mock import patch
 from mockredis import mock_strict_redis_client
 
 
-@patch("ckan.logic.action.get.package_search", package_search)
+@patch("ckan.controllers.package.get_action", package_search)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestDatajsonGeneration(TestAndino.TestAndino):
 

--- a/ckanext/gobar_theme/tests/tests_datajson.py
+++ b/ckanext/gobar_theme/tests/tests_datajson.py
@@ -7,6 +7,7 @@ from ckanext.gobar_theme.lib.datajson_actions import generate_new_cache_file, fi
     get_datasets_with_resources, get_ckan_datasets, CACHE_DIRECTORY
 from ckanext.gobar_theme.tests import TestAndino as TestAndino
 from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
+from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize
 import ckan.model as model
 import tempfile
 from ckan.tests import helpers as helpers
@@ -16,6 +17,8 @@ from mock import patch
 from mockredis import mock_strict_redis_client
 
 
+@patch("ckan.logic.action.get.package_search", package_search)
+@patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestDatajsonGeneration(TestAndino.TestAndino):
 
     def __init__(self):

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -12,6 +12,7 @@ from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
 from ckan.model import license
 from pylons.config import config
 from ckanapi import RemoteCKAN, LocalCKAN
+from ckan.logic.action.create import organization_create
 
 
 class TestHelpers(TestAndino.TestAndino):
@@ -36,7 +37,7 @@ class TestOrganizationHelpers(TestHelpers):
         #     self.edit_form_values(response, field_name='title', field_type='text', value="id-custom")
         # form = response.forms['google-tag-manager']
         # nt.assert_equals(form['container-id'].value, "id-custom")
-
+        return factories.Organization()
         lc = LocalCKAN()
         site_user = lc._get_action('get_site_user')({'ignore_auth': True}, ())
         apikey = site_user.get('apikey')

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -7,12 +7,161 @@ from mock import patch
 import ckan.tests.factories as factories
 import nose.tools as nt
 from ckanext.gobar_theme.tests import TestAndino
+import ckan.tests.helpers as helpers
 import ckanext.gobar_theme.helpers as gobar_helpers
 from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
 from ckan.model import license
-from pylons.config import config
-from ckanapi import RemoteCKAN, LocalCKAN
-from ckan.logic.action.create import organization_create
+from pylons import config
+from pylons import tmpl_context
+from ckan.common import c
+from paste.deploy.converters import asbool
+import ckan.common
+
+
+def before_search(self, search_params):
+    pass
+
+
+def package_search(context, data_dict):
+    # sometimes context['schema'] is None
+    schema = (context.get('schema') or logic.schema.default_package_search_schema())
+    # put the extras back into the data_dict so that the search can
+    # report needless parameters
+    data_dict.update(data_dict.get('__extras', {}))
+    data_dict.pop('__extras', None)
+
+    model = context['model']
+    session = context['session']
+    user = context.get('user')
+
+    # Move ext_ params to extras and remove them from the root of the search
+    # params, so they don't cause and error
+    data_dict['extras'] = data_dict.get('extras', {})
+    for key in [key for key in data_dict.keys() if key.startswith('ext_')]:
+        data_dict['extras'][key] = data_dict.pop(key)
+
+    # the extension may have decided that it is not necessary to perform
+    # the query
+    abort = data_dict.get('abort_search', False)
+
+    if data_dict.get('sort') in (None, 'rank'):
+        data_dict['sort'] = 'score desc, metadata_modified desc'
+
+    results = []
+    if not abort:
+        if asbool(data_dict.get('use_default_schema')):
+            data_source = 'data_dict'
+        else:
+            data_source = 'validated_data_dict'
+        data_dict.pop('use_default_schema', None)
+
+        result_fl = data_dict.get('fl')
+        if not result_fl:
+            data_dict['fl'] = 'id {0}'.format(data_source)
+        else:
+            data_dict['fl'] = ' '.join(result_fl)
+
+        # Remove before these hit solr FIXME: whitelist instead
+        include_private = asbool(data_dict.pop('include_private', False))
+        include_drafts = asbool(data_dict.pop('include_drafts', False))
+        data_dict.setdefault('fq', '')
+        if not include_private:
+            data_dict['fq'] = '+capacity:public ' + data_dict['fq']
+        if include_drafts:
+            data_dict['fq'] += ' +state:(active OR draft)'
+
+        # Pop these ones as Solr does not need them
+        extras = data_dict.pop('extras', None)
+
+        query = search.query_for(model.Package)
+        query.run(data_dict, permission_labels=None)
+
+        # Add them back so extensions can use them on after_search
+        data_dict['extras'] = extras
+
+        if result_fl:
+            for package in query.results:
+                if package.get('extras'):
+                    package.update(package['extras'] )
+                    package.pop('extras')
+                results.append(package)
+        else:
+            for package in query.results:
+                # get the package object
+                package_dict = package.get(data_source)
+                ## use data in search index if there
+                if package_dict:
+                    # the package_dict still needs translating when being viewed
+                    package_dict = json.loads(package_dict)
+                    results.append(package_dict)
+                else:
+                    pass
+
+        count = query.count
+        facets = query.facets
+    else:
+        count = 0
+        facets = {}
+        results = []
+
+    search_results = {
+        'count': count,
+        'facets': facets,
+        'results': results,
+        'sort': data_dict['sort']
+    }
+
+    # create a lookup table of group name to title for all the groups and
+    # organizations in the current search's facets.
+    group_names = []
+    for field_name in ('groups', 'organization'):
+        group_names.extend(facets.get(field_name, {}).keys())
+
+    groups = (session.query(model.Group.name, model.Group.title)
+                    .filter(model.Group.name.in_(group_names))
+                    .all()
+              if group_names else [])
+    group_titles_by_name = dict(groups)
+
+    # Transform facets into a more useful data structure.
+    restructured_facets = {}
+    for key, value in facets.items():
+        restructured_facets[key] = {
+            'title': key,
+            'items': []
+        }
+        for key_, value_ in value.items():
+            new_facet_dict = {}
+            new_facet_dict['name'] = key_
+            if key in ('groups', 'organization'):
+                display_name = group_titles_by_name.get(key_, key_)
+                display_name = display_name if display_name and display_name.strip() else key_
+                new_facet_dict['display_name'] = display_name
+            elif key == 'license_id':
+                license = model.Package.get_license_register().get(key_)
+                if license:
+                    new_facet_dict['display_name'] = license.title
+                else:
+                    new_facet_dict['display_name'] = key_
+            else:
+                new_facet_dict['display_name'] = key_
+            new_facet_dict['count'] = value_
+            restructured_facets[key]['items'].append(new_facet_dict)
+    search_results['search_facets'] = restructured_facets
+
+    # After extensions have had a chance to modify the facets, sort them by
+    # display name.
+    for facet in search_results['search_facets']:
+        search_results['search_facets'][facet]['items'] = sorted(
+            search_results['search_facets'][facet]['items'],
+            key=lambda facet: facet['display_name'], reverse=True)
+
+    return search_results
+
+
+import ckan.logic as logic
+import ckan.lib.search as search
+import ckan
 
 
 class TestHelpers(TestAndino.TestAndino):
@@ -23,32 +172,24 @@ class TestHelpers(TestAndino.TestAndino):
         self.admin = factories.Sysadmin()
 
 
+@patch("ckan.logic.action.get.package_search", package_search)
 class TestOrganizationHelpers(TestHelpers):
 
     def __init__(self):
         super(TestOrganizationHelpers, self).__init__()
 
     def create_organization(self, name, parent=''):
-        # env, response = self.get_page_response('/organization/new', admin_required=True)
-        # form = response.forms['organization-edit-form']
-        # data_dict = {{'field_name': 'title', 'field_type': 'text', 'value': name},
-        #              {'field_name': 'hierarchy', 'field_type': 'text', 'value': parent}}
-        # response = \
-        #     self.edit_form_values(response, field_name='title', field_type='text', value="id-custom")
-        # form = response.forms['google-tag-manager']
-        # nt.assert_equals(form['container-id'].value, "id-custom")
-        return AndinoOrganization.create(None, None, {'name': 'nombre'})
-        lc = LocalCKAN()
-        site_user = lc._get_action('get_site_user')({'ignore_auth': True}, ())
-        apikey = site_user.get('apikey')
-        site_url = gobar_helpers.search_for_value_in_config_file('ckan.site_url') or 'http://localhost'
-        portal = RemoteCKAN(site_url, apikey=apikey)
-        organization = {'name': name}
+        data_dict = {'name': name}
         if parent:
-            organization['groups'] = [{'name': parent}]
-        return portal.call_action('organization_create', data_dict=organization)
+            data_dict['groups'] = [{'name': parent}]
+        context = {'user': factories._get_action_user_name(data_dict)}
+        data_dict.setdefault('type', 'organization')
+        ckan.common.c = None
+        tmpl_context = None
+        return helpers.call_action('organization_create', context=context, **data_dict)
 
     def test_organization_can_be_created(self):
+        # import pdb; pdb.set_trace()
         nt.assert_equals(self.create_organization('nombre').get('name'), 'nombre')
 
     def test_organization_shows_1_dataset(self):
@@ -100,11 +241,3 @@ class TestLicenseHelpers(TestHelpers):
     def test_license_title_search_returns_correct_title(self):
         nt.assert_equals(gobar_helpers.get_license_title('odc-pddl'),
                          u'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
-
-
-class AndinoOrganization(factories.Organization):
-    # TODO: cuando se vaya a refactorear la suit de tests, pasar esto a un archivo separado
-
-    @classmethod
-    def create(cls, target_class, *args, **kwargs):
-        return super(AndinoOrganization, cls)._create(cls, target_class, *args, **kwargs)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -40,7 +40,7 @@ class TestOrganizationHelpers(TestHelpers):
         lc = LocalCKAN()
         site_user = lc._get_action('get_site_user')({'ignore_auth': True}, ())
         apikey = site_user.get('apikey')
-        site_url = gobar_helpers.search_for_value_in_config_file('ckan.site_url') or config.get('ckan.site_url')
+        site_url = gobar_helpers.search_for_value_in_config_file('ckan.site_url') or 'http://localhost'
         portal = RemoteCKAN(site_url, apikey=apikey)
         organization = {'name': name}
         if parent:

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -3,15 +3,15 @@
 import os
 import json
 import urllib2
-import ckan.tests.factories as factories
 import nose.tools as nt
+import ckan.tests.factories as factories
 import ckanext.gobar_theme.helpers as gobar_helpers
 from mock import patch
 from ckan.model import license
 from ckanext.gobar_theme.tests import TestAndino
 from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
 from ckanext.gobar_theme.tests.tools.organizations_manager import create_organization, package_search, group_dictize, \
-    get_facet_items_dict, get_action
+    get_facet_items_dict, get_action, get_request_param
 
 
 class TestHelpers(TestAndino.TestAndino):
@@ -22,7 +22,8 @@ class TestHelpers(TestAndino.TestAndino):
         self.admin = factories.Sysadmin()
 
 
-@patch("ckan.logic.get_action", get_action)
+@patch("ckan.lib.helpers.get_request_param", get_request_param)
+@patch("ckan.controllers.package.get_action", get_action)
 @patch("ckan.logic.action.get.package_search", package_search)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 @patch("ckanext.gobar_theme.helpers.get_facet_items_dict", get_facet_items_dict)
@@ -32,14 +33,13 @@ class TestOrganizationHelpers(TestHelpers):
         super(TestOrganizationHelpers, self).__init__()
 
     def test_organization_can_be_created(self):
-        # import pdb; pdb.set_trace()
         nt.assert_equals(create_organization(name='nombre').get('name'), 'nombre')
 
     def test_organization_shows_1_dataset(self):
         organization = create_organization(name='org')
         self.create_package_with_n_resources(1, {'owner_org': organization['id']})
-        organizations_info = gobar_helpers.organizations_basic_info()
-        nt.assert_equals(organizations_info[0].get('available_package_count'), 1)
+        organizations_info = {item['name']: item for item in gobar_helpers.organizations_basic_info()}
+        nt.assert_equals(organizations_info['org'].get('available_package_count'), 1)
 
 
 class TestLicenseHelpers(TestHelpers):

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -22,7 +22,7 @@ class TestHelpers(TestAndino.TestAndino):
         self.admin = factories.Sysadmin()
 
 
-@patch("ckan.controllers.package.get_action", get_action)
+@patch("ckan.logic.get_action", get_action)
 @patch("ckan.logic.action.get.package_search", package_search)
 @patch("ckan.lib.helpers.get_request_param", get_request_param)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -3,165 +3,15 @@
 import os
 import json
 import urllib2
-from mock import patch
 import ckan.tests.factories as factories
 import nose.tools as nt
-from ckanext.gobar_theme.tests import TestAndino
-import ckan.tests.helpers as helpers
 import ckanext.gobar_theme.helpers as gobar_helpers
-from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
+from mock import patch
 from ckan.model import license
-from pylons import config
-from pylons import tmpl_context
-from ckan.common import c
-from paste.deploy.converters import asbool
-import ckan.common
-
-
-def before_search(self, search_params):
-    pass
-
-
-def package_search(context, data_dict):
-    # sometimes context['schema'] is None
-    schema = (context.get('schema') or logic.schema.default_package_search_schema())
-    # put the extras back into the data_dict so that the search can
-    # report needless parameters
-    data_dict.update(data_dict.get('__extras', {}))
-    data_dict.pop('__extras', None)
-
-    model = context['model']
-    session = context['session']
-    user = context.get('user')
-
-    # Move ext_ params to extras and remove them from the root of the search
-    # params, so they don't cause and error
-    data_dict['extras'] = data_dict.get('extras', {})
-    for key in [key for key in data_dict.keys() if key.startswith('ext_')]:
-        data_dict['extras'][key] = data_dict.pop(key)
-
-    # the extension may have decided that it is not necessary to perform
-    # the query
-    abort = data_dict.get('abort_search', False)
-
-    if data_dict.get('sort') in (None, 'rank'):
-        data_dict['sort'] = 'score desc, metadata_modified desc'
-
-    results = []
-    if not abort:
-        if asbool(data_dict.get('use_default_schema')):
-            data_source = 'data_dict'
-        else:
-            data_source = 'validated_data_dict'
-        data_dict.pop('use_default_schema', None)
-
-        result_fl = data_dict.get('fl')
-        if not result_fl:
-            data_dict['fl'] = 'id {0}'.format(data_source)
-        else:
-            data_dict['fl'] = ' '.join(result_fl)
-
-        # Remove before these hit solr FIXME: whitelist instead
-        include_private = asbool(data_dict.pop('include_private', False))
-        include_drafts = asbool(data_dict.pop('include_drafts', False))
-        data_dict.setdefault('fq', '')
-        if not include_private:
-            data_dict['fq'] = '+capacity:public ' + data_dict['fq']
-        if include_drafts:
-            data_dict['fq'] += ' +state:(active OR draft)'
-
-        # Pop these ones as Solr does not need them
-        extras = data_dict.pop('extras', None)
-
-        query = search.query_for(model.Package)
-        query.run(data_dict, permission_labels=None)
-
-        # Add them back so extensions can use them on after_search
-        data_dict['extras'] = extras
-
-        if result_fl:
-            for package in query.results:
-                if package.get('extras'):
-                    package.update(package['extras'] )
-                    package.pop('extras')
-                results.append(package)
-        else:
-            for package in query.results:
-                # get the package object
-                package_dict = package.get(data_source)
-                ## use data in search index if there
-                if package_dict:
-                    # the package_dict still needs translating when being viewed
-                    package_dict = json.loads(package_dict)
-                    results.append(package_dict)
-                else:
-                    pass
-
-        count = query.count
-        facets = query.facets
-    else:
-        count = 0
-        facets = {}
-        results = []
-
-    search_results = {
-        'count': count,
-        'facets': facets,
-        'results': results,
-        'sort': data_dict['sort']
-    }
-
-    # create a lookup table of group name to title for all the groups and
-    # organizations in the current search's facets.
-    group_names = []
-    for field_name in ('groups', 'organization'):
-        group_names.extend(facets.get(field_name, {}).keys())
-
-    groups = (session.query(model.Group.name, model.Group.title)
-                    .filter(model.Group.name.in_(group_names))
-                    .all()
-              if group_names else [])
-    group_titles_by_name = dict(groups)
-
-    # Transform facets into a more useful data structure.
-    restructured_facets = {}
-    for key, value in facets.items():
-        restructured_facets[key] = {
-            'title': key,
-            'items': []
-        }
-        for key_, value_ in value.items():
-            new_facet_dict = {}
-            new_facet_dict['name'] = key_
-            if key in ('groups', 'organization'):
-                display_name = group_titles_by_name.get(key_, key_)
-                display_name = display_name if display_name and display_name.strip() else key_
-                new_facet_dict['display_name'] = display_name
-            elif key == 'license_id':
-                license = model.Package.get_license_register().get(key_)
-                if license:
-                    new_facet_dict['display_name'] = license.title
-                else:
-                    new_facet_dict['display_name'] = key_
-            else:
-                new_facet_dict['display_name'] = key_
-            new_facet_dict['count'] = value_
-            restructured_facets[key]['items'].append(new_facet_dict)
-    search_results['search_facets'] = restructured_facets
-
-    # After extensions have had a chance to modify the facets, sort them by
-    # display name.
-    for facet in search_results['search_facets']:
-        search_results['search_facets'][facet]['items'] = sorted(
-            search_results['search_facets'][facet]['items'],
-            key=lambda facet: facet['display_name'], reverse=True)
-
-    return search_results
-
-
-import ckan.logic as logic
-import ckan.lib.search as search
-import ckan
+from ckanext.gobar_theme.tests import TestAndino
+from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
+from ckanext.gobar_theme.tests.tools.organizations_manager import create_organization, package_search, group_dictize, \
+    get_facet_items_dict, get_action
 
 
 class TestHelpers(TestAndino.TestAndino):
@@ -172,28 +22,21 @@ class TestHelpers(TestAndino.TestAndino):
         self.admin = factories.Sysadmin()
 
 
+@patch("ckan.logic.get_action", get_action)
 @patch("ckan.logic.action.get.package_search", package_search)
+@patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
+@patch("ckanext.gobar_theme.helpers.get_facet_items_dict", get_facet_items_dict)
 class TestOrganizationHelpers(TestHelpers):
 
     def __init__(self):
         super(TestOrganizationHelpers, self).__init__()
 
-    def create_organization(self, name, parent=''):
-        data_dict = {'name': name}
-        if parent:
-            data_dict['groups'] = [{'name': parent}]
-        context = {'user': factories._get_action_user_name(data_dict)}
-        data_dict.setdefault('type', 'organization')
-        ckan.common.c = None
-        tmpl_context = None
-        return helpers.call_action('organization_create', context=context, **data_dict)
-
     def test_organization_can_be_created(self):
         # import pdb; pdb.set_trace()
-        nt.assert_equals(self.create_organization('nombre').get('name'), 'nombre')
+        nt.assert_equals(create_organization(name='nombre').get('name'), 'nombre')
 
     def test_organization_shows_1_dataset(self):
-        organization = self.create_organization('org')
+        organization = create_organization(name='org')
         self.create_package_with_n_resources(1, {'owner_org': organization['id']})
         organizations_info = gobar_helpers.organizations_basic_info()
         nt.assert_equals(organizations_info[0].get('available_package_count'), 1)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -107,4 +107,4 @@ class AndinoOrganization(factories.Organization):
 
     @classmethod
     def create(cls, target_class, *args, **kwargs):
-        return super(AndinoOrganization, cls)._create(target_class, *args, **kwargs)
+        return super(AndinoOrganization, cls)._create(cls, target_class, *args, **kwargs)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -37,7 +37,7 @@ class TestOrganizationHelpers(TestHelpers):
         #     self.edit_form_values(response, field_name='title', field_type='text', value="id-custom")
         # form = response.forms['google-tag-manager']
         # nt.assert_equals(form['container-id'].value, "id-custom")
-        return factories.Organization({'name': name})
+        return AndinoOrganization.create(None, None, {'name': 'nombre'})
         lc = LocalCKAN()
         site_user = lc._get_action('get_site_user')({'ignore_auth': True}, ())
         apikey = site_user.get('apikey')
@@ -100,3 +100,11 @@ class TestLicenseHelpers(TestHelpers):
     def test_license_title_search_returns_correct_title(self):
         nt.assert_equals(gobar_helpers.get_license_title('odc-pddl'),
                          u'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
+
+
+class AndinoOrganization(factories.Organization):
+    # TODO: cuando se vaya a refactorear la suit de tests, pasar esto a un archivo separado
+
+    @classmethod
+    def create(cls, target_class, *args, **kwargs):
+        return super(AndinoOrganization, cls)._create(target_class, *args, **kwargs)

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -37,7 +37,7 @@ class TestOrganizationHelpers(TestHelpers):
         #     self.edit_form_values(response, field_name='title', field_type='text', value="id-custom")
         # form = response.forms['google-tag-manager']
         # nt.assert_equals(form['container-id'].value, "id-custom")
-        return factories.Organization()
+        return factories.Organization({'name': name})
         lc = LocalCKAN()
         site_user = lc._get_action('get_site_user')({'ignore_auth': True}, ())
         apikey = site_user.get('apikey')
@@ -49,11 +49,11 @@ class TestOrganizationHelpers(TestHelpers):
         return portal.call_action('organization_create', data_dict=organization)
 
     def test_organization_can_be_created(self):
-        nt.assert_equals(self.create_organization('nombre'), 'nombre')
+        nt.assert_equals(self.create_organization('nombre').get('name'), 'nombre')
 
     def test_organization_shows_1_dataset(self):
         organization = self.create_organization('org')
-        self.create_package_with_n_resources(1, {'owner_org': organization})
+        self.create_package_with_n_resources(1, {'owner_org': organization['id']})
         organizations_info = gobar_helpers.organizations_basic_info()
         nt.assert_equals(organizations_info[0].get('available_package_count'), 1)
 

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -10,6 +10,7 @@ from ckanext.gobar_theme.tests import TestAndino
 import ckanext.gobar_theme.helpers as gobar_helpers
 from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
 from ckan.model import license
+from pylons.config import config
 from ckanapi import RemoteCKAN, LocalCKAN
 
 
@@ -39,7 +40,8 @@ class TestOrganizationHelpers(TestHelpers):
         lc = LocalCKAN()
         site_user = lc._get_action('get_site_user')({'ignore_auth': True}, ())
         apikey = site_user.get('apikey')
-        portal = RemoteCKAN(gobar_helpers.search_for_value_in_config_file('ckan.site_url'), apikey=apikey)
+        site_url = gobar_helpers.search_for_value_in_config_file('ckan.site_url') or config.get('ckan.site_url')
+        portal = RemoteCKAN(site_url, apikey=apikey)
         organization = {'name': name}
         if parent:
             organization['groups'] = [{'name': parent}]

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -22,9 +22,9 @@ class TestHelpers(TestAndino.TestAndino):
         self.admin = factories.Sysadmin()
 
 
-@patch("ckan.lib.helpers.get_request_param", get_request_param)
 @patch("ckan.controllers.package.get_action", get_action)
 @patch("ckan.logic.action.get.package_search", package_search)
+@patch("ckan.lib.helpers.get_request_param", get_request_param)
 @patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 @patch("ckanext.gobar_theme.helpers.get_facet_items_dict", get_facet_items_dict)
 class TestOrganizationHelpers(TestHelpers):

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -33,14 +33,14 @@ class TestOrganizationHelpers(TestHelpers):
     def test_organization_can_be_created(self):
         nt.assert_equals(orgs_manager.create_organization(name='nombre').get('name'), 'nombre')
 
-    @patch("ckanext.gobar_theme.helpers.get_facet_items_dict", orgs_manager.get_facet_items_dict)
+    @patch("ckan.lib.helpers.get_facet_items_dict", orgs_manager.get_facet_items_dict)
     def test_organization_shows_1_dataset(self):
         organization = orgs_manager.create_organization(name='org')
         self.create_package_with_n_resources(1, {'owner_org': organization['id']})
         organizations_info = {item['name']: item for item in gobar_helpers.organizations_basic_info()}
         nt.assert_equals(organizations_info['org'].get('available_package_count'), 1)
 
-    @patch("ckanext.gobar_theme.helpers.get_facet_items_dict", orgs_manager.get_facet_items_dict_org_with_child)
+    @patch("ckan.lib.helpers.get_facet_items_dict", orgs_manager.get_facet_items_dict_org_with_child)
     def test_organization_shows_2_datasets(self):
         father_organization = orgs_manager.create_organization(name='father')
         child_organization = orgs_manager.create_organization(name='child', parent='father')

--- a/ckanext/gobar_theme/tests/tests_resources.py
+++ b/ckanext/gobar_theme/tests/tests_resources.py
@@ -10,10 +10,13 @@ from mockredis import mock_strict_redis_client
 from ckanext.gobar_theme.lib.datajson_actions import CACHE_DIRECTORY
 from ckanext.gobar_theme.tests import TestAndino
 from ckanext.gobar_theme.tests.TestAndino import GobArConfigControllerForTest
+from ckanext.gobar_theme.tests.tools.organizations_manager import package_search, group_dictize
 
 submit_and_follow = helpers.submit_and_follow
 
 
+@patch("ckan.logic.action.get.package_search", package_search)
+@patch("ckan.lib.dictization.model_dictize.group_dictize", group_dictize)
 class TestResources(TestAndino.TestAndino):
 
     def __init__(self):

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -28,6 +28,7 @@ def create_organization(name, parent=''):
 
 # Mock functions
 
+
 def get_action(action):
     if _actions:
         if action not in _actions:
@@ -295,6 +296,12 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
 
 def get_facet_items_dict(facet, limit=None, exclude_active=False):
     return [{'active': False, 'count': 1, 'display_name': u'org', 'name': u'org'}]
+
+
+def get_facet_items_dict_org_with_child(facet, limit=None, exclude_active=False):
+    import pdb; pdb.set_trace()
+    return [{'active': False, 'count': 1, 'display_name': u'father', 'name': u'father'},
+            {'active': False, 'count': 1, 'display_name': u'child', 'name': u'child'}]
 
 
 def get_request_param(parameter_name, default=None):

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -41,20 +41,13 @@ def get_action(action):
             module = getattr(module, part)
         for k, v in module.__dict__.items():
             if not k.startswith('_'):
-                # Only load functions from the action module or already
-                # replaced functions.
                 if (hasattr(v, '__call__') and
                         (v.__module__ == module_path or
                          hasattr(v, '__replaced'))):
                     _actions[k] = v
-
-                    # Whitelist all actions defined in logic/action/get.py as
-                    # being side-effect free.
                     if action_module_name == 'get' and \
                        not hasattr(v, 'side_effect_free'):
                         v.side_effect_free = True
-
-    # Then overwrite them with any specific ones in the plugins:
     resolved_action_plugins = {}
     fetched_actions = {}
     chained_actions = defaultdict(list)
@@ -63,16 +56,9 @@ def get_action(action):
             if _is_chained_action(auth_function):
                 chained_actions[name].append(auth_function)
             elif name in resolved_action_plugins:
-                raise Exception(
-                    'The action %r is already implemented in %r' % (
-                        name,
-                        resolved_action_plugins[name]
-                    )
-                )
+                raise Exception('The action %r is already implemented in %r' % (name, resolved_action_plugins[name]))
             else:
                 resolved_action_plugins[name] = plugin.name
-                # Extensions are exempted from the auth audit for now
-                # This needs to be resolved later
                 auth_function.auth_audit_exempt = True
                 fetched_actions[name] = auth_function
     for name, func_list in chained_actions.iteritems():
@@ -82,30 +68,15 @@ def get_action(action):
         for func in reversed(func_list):
             prev_func = fetched_actions[name]
             fetched_actions[name] = functools.partial(func, prev_func)
-
-    # Use the updated ones in preference to the originals.
     _actions.update(fetched_actions)
-
-    # wrap the functions
     for action_name, _action in _actions.items():
         def make_wrapped(_action, action_name):
             def wrapped(context=None, data_dict=None, **kw):
                 if kw:
                     pass
-
                 context = _prepopulate_context(context)
-
-                # Auth Auditing - checks that the action function did call
-                # check_access (unless there is no accompanying auth function).
-                # We push the action name and id onto the __auth_audit stack
-                # before calling the action, and check_access removes it.
-                # (We need the id of the action in case the action is wrapped
-                # inside an action of the same name, which happens in the
-                # datastore)
                 context.setdefault('__auth_audit', [])
                 context['__auth_audit'].append((action_name, id(_action)))
-
-                # check_access(action_name, context, data_dict=None)
                 result = _action(context, data_dict, **kw)
                 try:
                     audit = context['__auth_audit'][-1]
@@ -113,27 +84,18 @@ def get_action(action):
                         if action_name not in authz.auth_functions_list():
                             pass
                         elif not getattr(_action, 'auth_audit_exempt', False):
-                            raise Exception(
-                                'Action function {0} did not call its '
-                                'auth function'
-                                .format(action_name))
-                        # remove from audit stack
+                            raise Exception('Action function {0} did not call its auth function'.format(action_name))
                         context['__auth_audit'].pop()
                 except IndexError:
                     pass
                 return result
             return wrapped
-
-        # If we have been called multiple times for example during tests then
-        # we need to make sure that we do not rewrap the actions.
         if hasattr(_action, '__replaced'):
             _actions[action_name] = _action.__replaced
             continue
 
         fn = make_wrapped(_action, action_name)
-        # we need to mirror the docstring
         fn.__doc__ = _action.__doc__
-        # we need to retain the side effect free behaviour
         if getattr(_action, 'side_effect_free', False):
             fn.side_effect_free = True
         _actions[action_name] = fn
@@ -141,38 +103,19 @@ def get_action(action):
     return _actions.get(action)
 
 
-
-
-
-
-
-
-
 def package_search(context, data_dict):
-    # sometimes context['schema'] is None
     schema = (context.get('schema') or logic.schema.default_package_search_schema())
-    # put the extras back into the data_dict so that the search can
-    # report needless parameters
     data_dict.update(data_dict.get('__extras', {}))
     data_dict.pop('__extras', None)
-
     model = context['model']
     session = context['session']
     user = context.get('user')
-
-    # Move ext_ params to extras and remove them from the root of the search
-    # params, so they don't cause and error
     data_dict['extras'] = data_dict.get('extras', {})
     for key in [key for key in data_dict.keys() if key.startswith('ext_')]:
         data_dict['extras'][key] = data_dict.pop(key)
-
-    # the extension may have decided that it is not necessary to perform
-    # the query
     abort = data_dict.get('abort_search', False)
-
     if data_dict.get('sort') in (None, 'rank'):
         data_dict['sort'] = 'score desc, metadata_modified desc'
-
     results = []
     if not abort:
         if asbool(data_dict.get('use_default_schema')):
@@ -186,8 +129,6 @@ def package_search(context, data_dict):
             data_dict['fl'] = 'id {0}'.format(data_source)
         else:
             data_dict['fl'] = ' '.join(result_fl)
-
-        # Remove before these hit solr FIXME: whitelist instead
         include_private = asbool(data_dict.pop('include_private', False))
         include_drafts = asbool(data_dict.pop('include_drafts', False))
         data_dict.setdefault('fq', '')
@@ -195,16 +136,10 @@ def package_search(context, data_dict):
             data_dict['fq'] = '+capacity:public ' + data_dict['fq']
         if include_drafts:
             data_dict['fq'] += ' +state:(active OR draft)'
-
-        # Pop these ones as Solr does not need them
         extras = data_dict.pop('extras', None)
-
         query = search.query_for(model.Package)
         query.run(data_dict, permission_labels=None)
-
-        # Add them back so extensions can use them on after_search
         data_dict['extras'] = extras
-
         if result_fl:
             for package in query.results:
                 if package.get('extras'):
@@ -213,43 +148,32 @@ def package_search(context, data_dict):
                 results.append(package)
         else:
             for package in query.results:
-                # get the package object
                 package_dict = package.get(data_source)
-                ## use data in search index if there
                 if package_dict:
-                    # the package_dict still needs translating when being viewed
                     package_dict = json.loads(package_dict)
                     results.append(package_dict)
                 else:
                     pass
-
         count = query.count
         facets = query.facets
     else:
         count = 0
         facets = {}
         results = []
-
     search_results = {
         'count': count,
         'facets': facets,
         'results': results,
         'sort': data_dict['sort']
     }
-
-    # create a lookup table of group name to title for all the groups and
-    # organizations in the current search's facets.
     group_names = []
     for field_name in ('groups', 'organization'):
         group_names.extend(facets.get(field_name, {}).keys())
-
     groups = (session.query(model.Group.name, model.Group.title)
                     .filter(model.Group.name.in_(group_names))
                     .all()
               if group_names else [])
     group_titles_by_name = dict(groups)
-
-    # Transform facets into a more useful data structure.
     restructured_facets = {}
     for key, value in facets.items():
         restructured_facets[key] = {
@@ -274,14 +198,10 @@ def package_search(context, data_dict):
             new_facet_dict['count'] = value_
             restructured_facets[key]['items'].append(new_facet_dict)
     search_results['search_facets'] = restructured_facets
-
-    # After extensions have had a chance to modify the facets, sort them by
-    # display name.
     for facet in search_results['search_facets']:
         search_results['search_facets'][facet]['items'] = sorted(
             search_results['search_facets'][facet]['items'],
             key=lambda facet: facet['display_name'], reverse=True)
-
     return search_results
 
 
@@ -290,53 +210,40 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
     assert packages_field in ('datasets', 'dataset_count', None)
     if packages_field == 'dataset_count':
         dataset_counts = context.get('dataset_counts', None)
-
     result_dict = d.table_dictize(group, context)
     result_dict.update(kw)
-
     result_dict['display_name'] = group.title or group.name
-
     if include_extras:
         result_dict['extras'] = ckan.lib.dictization.model_dictize.extras_dict_dictize(
             group._extras, context)
-
     context['with_capacity'] = True
-
     if packages_field:
         def get_packages_for_this_group(group_, just_the_count=False):
-            # Ask SOLR for the list of packages for this org/group
             q = {
                 'facet': 'false',
                 'rows': 0,
             }
-
             if group_.is_organization:
                 q['fq'] = 'owner_org:"{0}"'.format(group_.id)
             else:
                 q['fq'] = 'groups:"{0}"'.format(group_.name)
-
-            # Allow members of organizations to see private datasets.
             if group_.is_organization:
                 is_group_member = (context.get('user') and
                     authz.has_user_permission_for_group_or_org(
                         group_.id, context.get('user'), 'read'))
                 if is_group_member:
                     q['include_private'] = True
-
             if not just_the_count:
-                # Is there a packages limit in the context?
                 try:
                     packages_limit = context['limits']['packages']
                 except KeyError:
                     q['rows'] = 1000  # Only the first 1000 datasets are returned
                 else:
                     q['rows'] = packages_limit
-
             search_context = dict((k, v) for (k, v) in context.items()
                                   if k != 'schema')
             search_results = package_search(search_context, q)
             return search_results['count'], search_results['results']
-
         if packages_field == 'datasets':
             package_count, packages = get_packages_for_this_group(group)
             result_dict['packages'] = packages
@@ -345,35 +252,25 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
                 package_count, packages = get_packages_for_this_group(
                     group, just_the_count=True)
             else:
-                # Use the pre-calculated package_counts passed in.
                 facets = dataset_counts
                 if group.is_organization:
                     package_count = facets['owner_org'].get(group.id, 0)
                 else:
                     package_count = facets['groups'].get(group.name, 0)
-
         result_dict['package_count'] = package_count
-
     if include_tags:
-        # group tags are not creatable via the API yet, but that was(/is) a
-        # future intention (see kindly's commit 5c8df894 on 2011/12/23)
         result_dict['tags'] = ckan.lib.dictization.model_dictize.tag_list_dictize(
             ckan.lib.dictization.model_dictize._get_members(context, group, 'tags'),
             context)
-
     if include_groups:
-        # these sub-groups won't have tags or extras for speed
         result_dict['groups'] = ckan.lib.dictization.model_dictize.group_list_dictize(
             ckan.lib.dictization.model_dictize._get_members(context, group, 'groups'),
             context, include_groups=True)
-
     if include_users:
         result_dict['users'] = ckan.lib.dictization.model_dictize.user_list_dictize(
             ckan.lib.dictization.model_dictize._get_members(context, group, 'users'),
             context)
-
     context['with_capacity'] = False
-
     if context.get('for_view'):
         if result_dict['is_organization']:
             plugin = plugins.IOrganizationController
@@ -381,12 +278,9 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
             plugin = plugins.IGroupController
         for item in plugins.PluginImplementations(plugin):
             result_dict = item.before_view(result_dict)
-
     image_url = result_dict.get('image_url')
     result_dict['image_display_url'] = image_url
     if image_url and not image_url.startswith('http'):
-        #munge here should not have an effect only doing it incase
-        #of potential vulnerability of dodgy api input
         image_url = munge.munge_filename_legacy(image_url)
         result_dict['image_display_url'] = helpers.url_for_static(
             'uploads/group/%s' % result_dict.get('image_url'),

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -1,0 +1,401 @@
+# encoding: utf-8
+import json
+import functools
+import ckan.tests.helpers as helpers
+import ckan.common
+import ckan.plugins as p
+import ckan.lib.dictization as d
+import ckan.authz as authz
+import ckan.lib.munge as munge
+import ckan.plugins as plugins
+import ckan.logic as logic
+import ckan.lib.search as search
+import ckan.tests.factories as factories
+from ckan.logic import _actions, _is_chained_action, _prepopulate_context
+from collections import defaultdict
+from paste.deploy.converters import asbool
+
+
+def create_organization(name, parent=''):
+    data_dict = {'name': name}
+    if parent:
+        data_dict['groups'] = [{'name': parent}]
+    context = {'user': factories._get_action_user_name(data_dict)}
+    data_dict.setdefault('type', 'organization')
+    return helpers.call_action('organization_create', context=context, **data_dict)
+
+
+# Mock functions
+
+def get_action(action):
+    if _actions:
+        if action not in _actions:
+            if action == 'package_search':
+                return package_search
+            raise KeyError("Action '%s' not found" % action)
+        return _actions.get(action)
+    for action_module_name in ['get', 'create', 'update', 'delete', 'patch']:
+        module_path = 'ckan.logic.action.' + action_module_name
+        module = __import__(module_path)
+        for part in module_path.split('.')[1:]:
+            module = getattr(module, part)
+        for k, v in module.__dict__.items():
+            if not k.startswith('_'):
+                # Only load functions from the action module or already
+                # replaced functions.
+                if (hasattr(v, '__call__') and
+                        (v.__module__ == module_path or
+                         hasattr(v, '__replaced'))):
+                    _actions[k] = v
+
+                    # Whitelist all actions defined in logic/action/get.py as
+                    # being side-effect free.
+                    if action_module_name == 'get' and \
+                       not hasattr(v, 'side_effect_free'):
+                        v.side_effect_free = True
+
+    # Then overwrite them with any specific ones in the plugins:
+    resolved_action_plugins = {}
+    fetched_actions = {}
+    chained_actions = defaultdict(list)
+    for plugin in p.PluginImplementations(p.IActions):
+        for name, auth_function in plugin.get_actions().items():
+            if _is_chained_action(auth_function):
+                chained_actions[name].append(auth_function)
+            elif name in resolved_action_plugins:
+                raise Exception(
+                    'The action %r is already implemented in %r' % (
+                        name,
+                        resolved_action_plugins[name]
+                    )
+                )
+            else:
+                resolved_action_plugins[name] = plugin.name
+                # Extensions are exempted from the auth audit for now
+                # This needs to be resolved later
+                auth_function.auth_audit_exempt = True
+                fetched_actions[name] = auth_function
+    for name, func_list in chained_actions.iteritems():
+        if name not in fetched_actions:
+            raise Exception('The action %r is not found for chained action' % (
+                name))
+        for func in reversed(func_list):
+            prev_func = fetched_actions[name]
+            fetched_actions[name] = functools.partial(func, prev_func)
+
+    # Use the updated ones in preference to the originals.
+    _actions.update(fetched_actions)
+
+    # wrap the functions
+    for action_name, _action in _actions.items():
+        def make_wrapped(_action, action_name):
+            def wrapped(context=None, data_dict=None, **kw):
+                if kw:
+                    pass
+
+                context = _prepopulate_context(context)
+
+                # Auth Auditing - checks that the action function did call
+                # check_access (unless there is no accompanying auth function).
+                # We push the action name and id onto the __auth_audit stack
+                # before calling the action, and check_access removes it.
+                # (We need the id of the action in case the action is wrapped
+                # inside an action of the same name, which happens in the
+                # datastore)
+                context.setdefault('__auth_audit', [])
+                context['__auth_audit'].append((action_name, id(_action)))
+
+                # check_access(action_name, context, data_dict=None)
+                result = _action(context, data_dict, **kw)
+                try:
+                    audit = context['__auth_audit'][-1]
+                    if audit[0] == action_name and audit[1] == id(_action):
+                        if action_name not in authz.auth_functions_list():
+                            pass
+                        elif not getattr(_action, 'auth_audit_exempt', False):
+                            raise Exception(
+                                'Action function {0} did not call its '
+                                'auth function'
+                                .format(action_name))
+                        # remove from audit stack
+                        context['__auth_audit'].pop()
+                except IndexError:
+                    pass
+                return result
+            return wrapped
+
+        # If we have been called multiple times for example during tests then
+        # we need to make sure that we do not rewrap the actions.
+        if hasattr(_action, '__replaced'):
+            _actions[action_name] = _action.__replaced
+            continue
+
+        fn = make_wrapped(_action, action_name)
+        # we need to mirror the docstring
+        fn.__doc__ = _action.__doc__
+        # we need to retain the side effect free behaviour
+        if getattr(_action, 'side_effect_free', False):
+            fn.side_effect_free = True
+        _actions[action_name] = fn
+
+    return _actions.get(action)
+
+
+
+
+
+
+
+
+
+def package_search(context, data_dict):
+    # sometimes context['schema'] is None
+    schema = (context.get('schema') or logic.schema.default_package_search_schema())
+    # put the extras back into the data_dict so that the search can
+    # report needless parameters
+    data_dict.update(data_dict.get('__extras', {}))
+    data_dict.pop('__extras', None)
+
+    model = context['model']
+    session = context['session']
+    user = context.get('user')
+
+    # Move ext_ params to extras and remove them from the root of the search
+    # params, so they don't cause and error
+    data_dict['extras'] = data_dict.get('extras', {})
+    for key in [key for key in data_dict.keys() if key.startswith('ext_')]:
+        data_dict['extras'][key] = data_dict.pop(key)
+
+    # the extension may have decided that it is not necessary to perform
+    # the query
+    abort = data_dict.get('abort_search', False)
+
+    if data_dict.get('sort') in (None, 'rank'):
+        data_dict['sort'] = 'score desc, metadata_modified desc'
+
+    results = []
+    if not abort:
+        if asbool(data_dict.get('use_default_schema')):
+            data_source = 'data_dict'
+        else:
+            data_source = 'validated_data_dict'
+        data_dict.pop('use_default_schema', None)
+
+        result_fl = data_dict.get('fl')
+        if not result_fl:
+            data_dict['fl'] = 'id {0}'.format(data_source)
+        else:
+            data_dict['fl'] = ' '.join(result_fl)
+
+        # Remove before these hit solr FIXME: whitelist instead
+        include_private = asbool(data_dict.pop('include_private', False))
+        include_drafts = asbool(data_dict.pop('include_drafts', False))
+        data_dict.setdefault('fq', '')
+        if not include_private:
+            data_dict['fq'] = '+capacity:public ' + data_dict['fq']
+        if include_drafts:
+            data_dict['fq'] += ' +state:(active OR draft)'
+
+        # Pop these ones as Solr does not need them
+        extras = data_dict.pop('extras', None)
+
+        query = search.query_for(model.Package)
+        query.run(data_dict, permission_labels=None)
+
+        # Add them back so extensions can use them on after_search
+        data_dict['extras'] = extras
+
+        if result_fl:
+            for package in query.results:
+                if package.get('extras'):
+                    package.update(package['extras'] )
+                    package.pop('extras')
+                results.append(package)
+        else:
+            for package in query.results:
+                # get the package object
+                package_dict = package.get(data_source)
+                ## use data in search index if there
+                if package_dict:
+                    # the package_dict still needs translating when being viewed
+                    package_dict = json.loads(package_dict)
+                    results.append(package_dict)
+                else:
+                    pass
+
+        count = query.count
+        facets = query.facets
+    else:
+        count = 0
+        facets = {}
+        results = []
+
+    search_results = {
+        'count': count,
+        'facets': facets,
+        'results': results,
+        'sort': data_dict['sort']
+    }
+
+    # create a lookup table of group name to title for all the groups and
+    # organizations in the current search's facets.
+    group_names = []
+    for field_name in ('groups', 'organization'):
+        group_names.extend(facets.get(field_name, {}).keys())
+
+    groups = (session.query(model.Group.name, model.Group.title)
+                    .filter(model.Group.name.in_(group_names))
+                    .all()
+              if group_names else [])
+    group_titles_by_name = dict(groups)
+
+    # Transform facets into a more useful data structure.
+    restructured_facets = {}
+    for key, value in facets.items():
+        restructured_facets[key] = {
+            'title': key,
+            'items': []
+        }
+        for key_, value_ in value.items():
+            new_facet_dict = {}
+            new_facet_dict['name'] = key_
+            if key in ('groups', 'organization'):
+                display_name = group_titles_by_name.get(key_, key_)
+                display_name = display_name if display_name and display_name.strip() else key_
+                new_facet_dict['display_name'] = display_name
+            elif key == 'license_id':
+                license = model.Package.get_license_register().get(key_)
+                if license:
+                    new_facet_dict['display_name'] = license.title
+                else:
+                    new_facet_dict['display_name'] = key_
+            else:
+                new_facet_dict['display_name'] = key_
+            new_facet_dict['count'] = value_
+            restructured_facets[key]['items'].append(new_facet_dict)
+    search_results['search_facets'] = restructured_facets
+
+    # After extensions have had a chance to modify the facets, sort them by
+    # display name.
+    for facet in search_results['search_facets']:
+        search_results['search_facets'][facet]['items'] = sorted(
+            search_results['search_facets'][facet]['items'],
+            key=lambda facet: facet['display_name'], reverse=True)
+
+    return search_results
+
+
+def group_dictize(group, context, include_groups=True, include_tags=True, include_users=True, include_extras=True,
+                  packages_field='datasets', **kw):
+    assert packages_field in ('datasets', 'dataset_count', None)
+    if packages_field == 'dataset_count':
+        dataset_counts = context.get('dataset_counts', None)
+
+    result_dict = d.table_dictize(group, context)
+    result_dict.update(kw)
+
+    result_dict['display_name'] = group.title or group.name
+
+    if include_extras:
+        result_dict['extras'] = ckan.lib.dictization.model_dictize.extras_dict_dictize(
+            group._extras, context)
+
+    context['with_capacity'] = True
+
+    if packages_field:
+        def get_packages_for_this_group(group_, just_the_count=False):
+            # Ask SOLR for the list of packages for this org/group
+            q = {
+                'facet': 'false',
+                'rows': 0,
+            }
+
+            if group_.is_organization:
+                q['fq'] = 'owner_org:"{0}"'.format(group_.id)
+            else:
+                q['fq'] = 'groups:"{0}"'.format(group_.name)
+
+            # Allow members of organizations to see private datasets.
+            if group_.is_organization:
+                is_group_member = (context.get('user') and
+                    authz.has_user_permission_for_group_or_org(
+                        group_.id, context.get('user'), 'read'))
+                if is_group_member:
+                    q['include_private'] = True
+
+            if not just_the_count:
+                # Is there a packages limit in the context?
+                try:
+                    packages_limit = context['limits']['packages']
+                except KeyError:
+                    q['rows'] = 1000  # Only the first 1000 datasets are returned
+                else:
+                    q['rows'] = packages_limit
+
+            search_context = dict((k, v) for (k, v) in context.items()
+                                  if k != 'schema')
+            search_results = package_search(search_context, q)
+            return search_results['count'], search_results['results']
+
+        if packages_field == 'datasets':
+            package_count, packages = get_packages_for_this_group(group)
+            result_dict['packages'] = packages
+        else:
+            if dataset_counts is None:
+                package_count, packages = get_packages_for_this_group(
+                    group, just_the_count=True)
+            else:
+                # Use the pre-calculated package_counts passed in.
+                facets = dataset_counts
+                if group.is_organization:
+                    package_count = facets['owner_org'].get(group.id, 0)
+                else:
+                    package_count = facets['groups'].get(group.name, 0)
+
+        result_dict['package_count'] = package_count
+
+    if include_tags:
+        # group tags are not creatable via the API yet, but that was(/is) a
+        # future intention (see kindly's commit 5c8df894 on 2011/12/23)
+        result_dict['tags'] = ckan.lib.dictization.model_dictize.tag_list_dictize(
+            ckan.lib.dictization.model_dictize._get_members(context, group, 'tags'),
+            context)
+
+    if include_groups:
+        # these sub-groups won't have tags or extras for speed
+        result_dict['groups'] = ckan.lib.dictization.model_dictize.group_list_dictize(
+            ckan.lib.dictization.model_dictize._get_members(context, group, 'groups'),
+            context, include_groups=True)
+
+    if include_users:
+        result_dict['users'] = ckan.lib.dictization.model_dictize.user_list_dictize(
+            ckan.lib.dictization.model_dictize._get_members(context, group, 'users'),
+            context)
+
+    context['with_capacity'] = False
+
+    if context.get('for_view'):
+        if result_dict['is_organization']:
+            plugin = plugins.IOrganizationController
+        else:
+            plugin = plugins.IGroupController
+        for item in plugins.PluginImplementations(plugin):
+            result_dict = item.before_view(result_dict)
+
+    image_url = result_dict.get('image_url')
+    result_dict['image_display_url'] = image_url
+    if image_url and not image_url.startswith('http'):
+        #munge here should not have an effect only doing it incase
+        #of potential vulnerability of dodgy api input
+        image_url = munge.munge_filename_legacy(image_url)
+        result_dict['image_display_url'] = helpers.url_for_static(
+            'uploads/group/%s' % result_dict.get('image_url'),
+            qualified=True
+        )
+    return result_dict
+
+
+def get_facet_items_dict(facet, limit=None, exclude_active=False):
+    from ckanext.gobar_theme.tests.TestAndino import TestAndino
+    _, response = TestAndino.get_page_response(TestAndino(), '/dataset', admin_required=True)
+    return response.c.search_facets

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -104,10 +104,6 @@ def get_action(action):
     return _actions.get(action)
 
 
-def get_package_search(object):
-    return package_search
-
-
 def package_search(context, data_dict):
     schema = (context.get('schema') or logic.schema.default_package_search_schema())
     data_dict.update(data_dict.get('__extras', {}))
@@ -298,12 +294,6 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
 
 
 def get_facet_items_dict(facet, limit=None, exclude_active=False):
-    # from ckanext.gobar_theme.tests.TestAndino import TestAndino  # Importo acá para evitar errores por dependencias
-    # _, response = TestAndino.get_page_response(TestAndino(), '/dataset', admin_required=True)
-    # from ckanext.gobar_theme.helpers import organizations_basic_info
-    # # info = organizations_basic_info()
-    # import pdb; pdb.set_trace()
-    # return response.c.search_facets.get('organization')['items']
     return [{'active': False, 'count': 1, 'display_name': u'org', 'name': u'org'}]
 
 

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -11,6 +11,7 @@ import ckan.lib.dictization as d
 import ckan.lib.search as search
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
+from ckan import model
 from collections import defaultdict
 from paste.deploy.converters import asbool
 from ckan.logic import _actions, _is_chained_action, _prepopulate_context
@@ -103,12 +104,16 @@ def get_action(action):
     return _actions.get(action)
 
 
+def get_package_search(object):
+    return package_search
+
+
 def package_search(context, data_dict):
     schema = (context.get('schema') or logic.schema.default_package_search_schema())
     data_dict.update(data_dict.get('__extras', {}))
     data_dict.pop('__extras', None)
-    model = context['model']
-    session = context['session']
+    session = model.Session
+    # session = context['session']
     user = context.get('user')
     data_dict['extras'] = data_dict.get('extras', {})
     for key in [key for key in data_dict.keys() if key.startswith('ext_')]:
@@ -202,6 +207,7 @@ def package_search(context, data_dict):
         search_results['search_facets'][facet]['items'] = sorted(
             search_results['search_facets'][facet]['items'],
             key=lambda facet: facet['display_name'], reverse=True)
+
     return search_results
 
 
@@ -218,6 +224,7 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
             group._extras, context)
     context['with_capacity'] = True
     if packages_field:
+
         def get_packages_for_this_group(group_, just_the_count=False):
             q = {
                 'facet': 'false',
@@ -244,6 +251,7 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
                                   if k != 'schema')
             search_results = package_search(search_context, q)
             return search_results['count'], search_results['results']
+
         if packages_field == 'datasets':
             package_count, packages = get_packages_for_this_group(group)
             result_dict['packages'] = packages
@@ -290,9 +298,13 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
 
 
 def get_facet_items_dict(facet, limit=None, exclude_active=False):
-    from ckanext.gobar_theme.tests.TestAndino import TestAndino  # Importo acá para evitar errores por dependencias
-    _, response = TestAndino.get_page_response(TestAndino(), '/dataset', admin_required=True)
-    return response.c.search_facets.get('organization')['items']
+    # from ckanext.gobar_theme.tests.TestAndino import TestAndino  # Importo acá para evitar errores por dependencias
+    # _, response = TestAndino.get_page_response(TestAndino(), '/dataset', admin_required=True)
+    # from ckanext.gobar_theme.helpers import organizations_basic_info
+    # # info = organizations_basic_info()
+    # import pdb; pdb.set_trace()
+    # return response.c.search_facets.get('organization')['items']
+    return [{'active': False, 'count': 1, 'display_name': u'org', 'name': u'org'}]
 
 
 def get_request_param(parameter_name, default=None):

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -1,19 +1,19 @@
 # encoding: utf-8
 import json
 import functools
-import ckan.tests.helpers as helpers
 import ckan.common
 import ckan.plugins as p
-import ckan.lib.dictization as d
-import ckan.authz as authz
-import ckan.lib.munge as munge
-import ckan.plugins as plugins
 import ckan.logic as logic
+import ckan.authz as authz
+import ckan.plugins as plugins
+import ckan.lib.munge as munge
+import ckan.lib.dictization as d
 import ckan.lib.search as search
+import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
-from ckan.logic import _actions, _is_chained_action, _prepopulate_context
 from collections import defaultdict
 from paste.deploy.converters import asbool
+from ckan.logic import _actions, _is_chained_action, _prepopulate_context
 
 
 def create_organization(name, parent=''):
@@ -398,4 +398,8 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
 def get_facet_items_dict(facet, limit=None, exclude_active=False):
     from ckanext.gobar_theme.tests.TestAndino import TestAndino
     _, response = TestAndino.get_page_response(TestAndino(), '/dataset', admin_required=True)
-    return response.c.search_facets
+    return response.c.search_facets.get('organization')['items']
+
+
+def get_request_param(parameter_name, default=None):
+    return None

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -299,7 +299,6 @@ def get_facet_items_dict(facet, limit=None, exclude_active=False):
 
 
 def get_facet_items_dict_org_with_child(facet, limit=None, exclude_active=False):
-    import pdb; pdb.set_trace()
     return [{'active': False, 'count': 1, 'display_name': u'father', 'name': u'father'},
             {'active': False, 'count': 1, 'display_name': u'child', 'name': u'child'}]
 

--- a/ckanext/gobar_theme/tests/tools/organizations_manager.py
+++ b/ckanext/gobar_theme/tests/tools/organizations_manager.py
@@ -290,7 +290,7 @@ def group_dictize(group, context, include_groups=True, include_tags=True, includ
 
 
 def get_facet_items_dict(facet, limit=None, exclude_active=False):
-    from ckanext.gobar_theme.tests.TestAndino import TestAndino
+    from ckanext.gobar_theme.tests.TestAndino import TestAndino  # Importo acá para evitar errores por dependencias
     _, response = TestAndino.get_page_response(TestAndino(), '/dataset', admin_required=True)
     return response.c.search_facets.get('organization')['items']
 


### PR DESCRIPTION
Se realizaron cambios en los helpers de organizaciones, snippets, y algunos tests. También se crearon tests nuevos para el manejo de organizaciones.

Próximamente, se modificarán algunos helpers y tests relacionados a este PR en el issue #406.

#### Cómo probar el fix

1. Levantar una instancia de Andino usando este branch.
2. Crear un grupo específico (theme), una organización y dos datasets;
  a. El primer dataset debe tener el grupo creado al principio.
  b. El segundo dataset no debe tener ningún grupo específico creado.
3. Ir a `/dataset` y asegurarse de que, al filtrar por el grupo específico, en el filtro de la organización solamente aparezca que hay un dataset disponible (no 2).

Closes #404.