### PR TITLE
Fix sección de datasets destacados

### DIFF
--- a/ckanext/gobar_theme/controller.py
+++ b/ckanext/gobar_theme/controller.py
@@ -36,7 +36,9 @@ class GobArHomeController(HomeController):
             'for_view': True
         }
         data_dict = {
-            'q': ''
+            'q': '',
+            'fq': 'home_featured:true',
+            'rows': 500
         }
         search = logic.get_action('package_search')(context, data_dict)
         if 'results' in search:


### PR DESCRIPTION
## Cómo probar la solución
1. Crear 502 datasets; 501 destacados, 1 no destacado.
2. Ir a la home y asegurarse de que hay 500 datasets, y todos deben haber sido marcados como destacados (el que _no_ está destacado no debe figurar).