### PR TITLE
Fix visual al reordenar recursos

### DIFF
--- a/ckanext/gobar_theme/templates/gobar_page.html
+++ b/ckanext/gobar_theme/templates/gobar_page.html
@@ -39,7 +39,6 @@
     {% endif %}
     {% resource 'gobar_js/libs/bootstrap_scripts.js' %}
     {% resource 'gobar_js/libs/BootstrapMenu.js' %}
-    {% resource 'gobar_js/libs/jquery-sortable.js' %}
     {% resource 'gobar_js/console_message.js' %}
     {% resource 'gobar_js/replace_svg.js' %}
     {% resource 'gobar_js/forms/custom_popup.js' %}

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form_attributes.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form_attributes.html
@@ -170,3 +170,4 @@
 </div>
 
 {% resource 'gobar_js/forms/resource_form.js' %}
+{% resource 'gobar_js/libs/jquery-sortable.js' %}


### PR DESCRIPTION
## Cómo probar la solución
1. Crear un dataset con un recurso (o más)
2. Entrar al formulario de edición de datasets -> Editar Recursos -> Click en Reorder Resources
3. Mover algún recurso. No debería moverse a otro lado de la pantalla, sino seguir el movimiento del mouse correctamente.

Closes #410.