### PR TITLE
Fix botón VOLVER en el formulario de recursos

### DIFF
--- a/ckanext/gobar_theme/templates/package/resource_edit_base.html
+++ b/ckanext/gobar_theme/templates/package/resource_edit_base.html
@@ -12,7 +12,7 @@
             <div id="edit-package" class="col-xs-12 col-md-10 col-md-offset-1">
                 <div class="col-xs-12 col-md-10 col-md-offset-1">
                     <div class="back-btn">
-                        <a href="{{ h.url_for(controller='package', action='resource_read', id=res.package_id, resource_id=res.id) }}">
+                        <a href={{ referer_url }}>
                             <i class="icon-chevron-left"></i>
                             VOLVER
                         </a>


### PR DESCRIPTION
## Cómo probar la solución

1. Crear un dataset con un recurso
2. Ingresar al formulario de edición del recurso creado
3. Hacer click en el botón VOLVER. Se debe redirigir a la página del recurso
4. Ingresar al formulario para crear un nuevo recurso
5. Hacer click en el botón VOLVER. Se debe redirigir a la página del dataset para el cual se habría creado el recurso

Closes #409.