### PR TITLE
Clases iconos columnas recursos

### DIFF
--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -10171,7 +10171,7 @@ div.about-components > pre{
   float: left;
 }
 
-.icon-ellipsis-vertical.col-options {
+.fa.fa-ellipsis-v.col-options {
   font-size: 20px;
   position: absolute;
   right: 0;

--- a/ckanext/gobar_theme/templates/package/snippets/resource_form_attributes.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_form_attributes.html
@@ -15,7 +15,7 @@
             <div class="control-group control-full">
                 <div class="resource-attributes-header">
                     <div>Columna</div>
-                    <i class="icon-ellipsis-vertical col-options"></i>
+                    <i class="fa fa-ellipsis-v col-options"></i>
                 </div>
 
                 <div class="col-xs-6 resource-attributes-input-container">


### PR DESCRIPTION
## Cómo probar la solución

Entrar al formulario de creación/edición de recursos y asegurarse de que haya un ícono de tres puntos para las columnas de la sección _Documentación de los campos del recurso_

Closes #411.