### PR TITLE
localhost es una URL válida como página de referencia

### DIFF
--- a/ckanext/gobar_theme/js/package/form_actions.js
+++ b/ckanext/gobar_theme/js/package/form_actions.js
@@ -283,7 +283,7 @@ $(document).ready( function(){
 $(document).ready( function(){
     $('#dataset-edit').on("submit", function(e) {
         var regex = new RegExp(
-            /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)[a-z0-9]+([\-.]{1}[a-z0-9]+)*(\.[a-z0-9]{2,5}|(:[0-9]{1,5}))(\/.*)?$/
+            /^(localhost|http:\/\/localhost|https:\/\/localhost)|(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)[a-z0-9]+([\-.]{1}[a-z0-9]+)*(\.[a-z0-9]{2,5}|(:[0-9]{1,5}))(\/.*)?$/
         );
         if (!$('#field-url').val().match(regex)) {
             e.preventDefault();


### PR DESCRIPTION
Closes #431 

Agrego "localhost" al regex que comprueba que la URL de página de referencia sea una URL válida.