### PR TITLE
No muestro el modal inicial si estamos en localhost

### DIFF
--- a/ckanext/gobar_theme/js/config/greetings.js
+++ b/ckanext/gobar_theme/js/config/greetings.js
@@ -1,4 +1,6 @@
 $(function () {
+    if (!window.location.hostname === 'localhost') { return }
+
     $('#greetings-modal').modal('show');
     $('#greetings-modal .dismiss-greetings').on('click', function() {
         $.post('/configurar/mensaje_de_bienvenida', {});

--- a/ckanext/gobar_theme/js/config/greetings.js
+++ b/ckanext/gobar_theme/js/config/greetings.js
@@ -1,5 +1,5 @@
 $(function () {
-    if (!window.location.hostname === 'localhost') { return }
+    if (window.location.hostname === 'localhost') { return }
 
     $('#greetings-modal').modal('show');
     $('#greetings-modal .dismiss-greetings').on('click', function() {


### PR DESCRIPTION
Closes #430 

Si estamos usando la aplicación en localhost, al iniciar sesión por primera vez no vemos el modal que pide revisar las guías de uso.