### PR TITLE
Cambiar datapusher por xloader

### DIFF
--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -5,11 +5,11 @@ import os
 import re
 import urlparse
 
+import moment
 import ckan.lib.base as base
 import ckan.lib.helpers as h
 import ckan.logic as logic
 import ckan.model as model
-import moment
 from ckan.common import request, c
 from pylons import config
 

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -306,6 +306,7 @@ class GobArConfigController(base.BaseController):
     def edit_datapusher_commands(self):
         if 'datapusher' not in config.get('ckan.plugins', ''):
             return h.redirect_to('home')
+        self._authorize()
         if request.method == 'POST':
             from ckanext.gobar_theme.helpers.cron import create_or_update_cron_job
             params = parse_params(request.POST)

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -304,30 +304,29 @@ class GobArConfigController(base.BaseController):
         return base.render('config/config_15_google_dataset_search.html')
 
     def edit_datapusher_commands(self):
-        if 'datapusher' in config.get('ckan.plugins', ''):
-            self._authorize()
-            if request.method == 'POST':
-                from ckanext.gobar_theme.helpers.cron import create_or_update_cron_job
-                params = parse_params(request.POST)
-                config_dict = self._read_config()
-                schedule_hour = params.get('schedule-hour').strip()
-                schedule_minute = params.get('schedule-minute').strip()
-                config_dict['datapusher'] = {
-                    'schedule-hour': schedule_hour,
-                    'schedule-minute': schedule_minute
-                }
-                self._set_config(config_dict)
-
-                # Creamos el cron job, reemplazando el anterior si ya existía
-                command = '{0} datapusher submit_all {1} && ' \
-                          '{0} views create {1}'\
-                    .format('{} --plugin=ckan'.format(self.get_paster_path()),
-                            '-y -c {}'.format(self.get_config_file_path()))
-                comment = 'datapusher - submit_all'
-                create_or_update_cron_job(command, hour=schedule_hour, minute=schedule_minute, comment=comment)
-            return base.render('config/config_18_datapusher_commands.html')
-        else:
+        if 'datapusher' not in config.get('ckan.plugins', ''):
             return h.redirect_to('home')
+        if request.method == 'POST':
+            from ckanext.gobar_theme.helpers.cron import create_or_update_cron_job
+            params = parse_params(request.POST)
+            config_dict = self._read_config()
+            schedule_hour = params.get('schedule-hour').strip()
+            schedule_minute = params.get('schedule-minute').strip()
+            config_dict['datapusher'] = {
+                'schedule-hour': schedule_hour,
+                'schedule-minute': schedule_minute
+            }
+            self._set_config(config_dict)
+
+            # Creamos el cron job, reemplazando el anterior si ya existía
+            command = '{0} datapusher submit_all {1} && ' \
+                      '{0} views create {1}' \
+                .format('{} --plugin=ckan'.format(self.get_paster_path()),
+                        '-y -c {}'.format(self.get_config_file_path()))
+            comment = 'datapusher - submit_all'
+            create_or_update_cron_job(command, hour=schedule_hour, minute=schedule_minute, comment=comment)
+        return base.render('config/config_18_datapusher_commands.html')
+
 
     def edit_google_tag_manager(self):
         self._authorize()

--- a/ckanext/gobar_theme/config_controller.py
+++ b/ckanext/gobar_theme/config_controller.py
@@ -327,7 +327,6 @@ class GobArConfigController(base.BaseController):
             create_or_update_cron_job(command, hour=schedule_hour, minute=schedule_minute, comment=comment)
         return base.render('config/config_18_datapusher_commands.html')
 
-
     def edit_google_tag_manager(self):
         self._authorize()
         if request.method == 'POST':

--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -9821,14 +9821,9 @@ ul.activity {
   ul.activity li.item {
     padding: 0 0 5px 0;
     border-bottom: solid 1px #eaeced;
-    margin: 0 0 5px 0;
-    display: none; }
+    margin: 0 0 5px 0; }
     ul.activity li.item p {
       margin: 5px; }
-  ul.activity li.load-more {
-    display: none !important; }
-  ul.activity li.xloader-log {
-    display: list-item !important; }
 
 div.button-pre{
   margin-top: 20px;

--- a/ckanext/gobar_theme/styles/css/gobar_style.css
+++ b/ckanext/gobar_theme/styles/css/gobar_style.css
@@ -9827,6 +9827,8 @@ ul.activity {
       margin: 5px; }
   ul.activity li.load-more {
     display: none !important; }
+  ul.activity li.xloader-log {
+    display: list-item !important; }
 
 div.button-pre{
   margin-top: 20px;

--- a/ckanext/gobar_theme/templates/config/navbar.html
+++ b/ckanext/gobar_theme/templates/config/navbar.html
@@ -76,9 +76,12 @@
            class="section-link {{ 'active' if c.action == 'edit_google_dataset_search' else '' }}">
             Google Dataset Search
         </a>
-        <a href="{{ h.url_for(controller='ckanext.gobar_theme.config_controller:GobArConfigController', action='edit_datapusher_commands') }}"
-           class="section-link {{ 'active' if c.action == 'edit_datapusher_commands' else '' }}">
-            Datapusher
+        {% if 'datapusher' in g.plugins %}
+            <a href="{{ h.url_for(controller='ckanext.gobar_theme.config_controller:GobArConfigController', action='edit_datapusher_commands') }}"
+               class="section-link {{ 'active' if c.action == 'edit_datapusher_commands' else '' }}">
+                Datapusher
+            </a>
+        {% endif %}
         <a href="{{ h.url_for(controller='ckanext.gobar_theme.config_controller:GobArConfigController', action='edit_google_tag_manager') }}"
            class="section-link {{ 'active' if c.action == 'edit_google_tag_manager' else '' }}">
             Google Tag Manager

--- a/ckanext/gobar_theme/templates/package/snippets/resource_nav.html
+++ b/ckanext/gobar_theme/templates/package/snippets/resource_nav.html
@@ -3,21 +3,26 @@
 {% if res %}
     {% set pkg = c.pkg_dict or pkg_dict %}
     <div class="resource-nav container-fluid">
-        {% set with_datapusher = 'datapusher' in g.plugins %}
+        {% if 'xloader' in g.plugins %}
+            {% set plugin_url = h.url_for(controller='ckanext.xloader.controllers:ResourceDataController', action='resource_data', id=pkg.name, resource_id=res.id) %}
+        {% elif 'datapusher' in g.plugins %}
+            {% set plugin_url =  h.url_for('resource_data', id=pkg.name, resource_id=res.id) %}
+        {% endif %}
+
         <a href="{{ h.url_for('resource_edit', id=pkg.name, resource_id=res.id) }}">
-            <div class="{{ 'col-xs-4' if with_datapusher else 'col-xs-6' }} {{ 'active' if current == 'edit' }}">
+            <div class="{{ 'col-xs-4' if plugin_url else 'col-xs-6' }} {{ 'active' if current == 'edit' }}">
                 Editar recurso
             </div>
         </a>
-        {% if with_datapusher %}
-            <a href="{{ h.url_for('resource_data', id=pkg.name, resource_id=res.id) }}">
+        {% if plugin_url %}
+            <a href="{{ plugin_url }}">
                 <div class="col-xs-4 {{ 'active' if current == 'datastore' }}">
                     DataStore
                 </div>
             </a>
         {% endif %}
         <a href="{{ h.url_for('views', id=pkg.name, resource_id=res.id) }}">
-            <div class="{{ 'col-xs-4' if with_datapusher else 'col-xs-6' }} {{ 'active' if current == 'views'}}">
+            <div class="{{ 'col-xs-4' if plugin_url else 'col-xs-6' }} {{ 'active' if current == 'views'}}">
                 Vistas
             </div>
         </a>

--- a/ckanext/gobar_theme/templates/xloader/resource_data.html
+++ b/ckanext/gobar_theme/templates/xloader/resource_data.html
@@ -1,0 +1,94 @@
+{% extends "package/resource_edit_base.html" %}
+{% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}{% endblock %}
+
+{% block form %}
+    {% set action = h.url_for(controller='ckanext.xloader.controllers:ResourceDataController', action='resource_data', id=pkg.name, resource_id=res.id) %}
+    {% set show_table = true %}
+
+    <form method="post" action="{{ action }}" class="datapusher-form">
+
+        {% snippet'package/snippets/resource_nav.html', current='datastore' %}
+
+        <div class="control-group">
+            <button class="btn btn-primary" name="save" type="submit">
+                <i class="fa fa-cloud-upload"></i> {{ _('Upload to DataStore') }}
+            </button>
+        </div>
+
+        {% if status.error and status.error.message %}
+            {% set show_table = false %}
+            <div class="alert alert-error">
+                <strong>{{ _('Upload error:') }}</strong> {{ status.error.message }}
+            </div>
+        {% elif status.task_info and status.task_info.error %}
+            <div class="alert alert-error">
+                {% if status.task_info.error is string %}
+                    <strong>{{ _('Error:') }}</strong> {{ status.task_info.error }}
+                {% elif status.task_info.error is mapping %}
+                    <strong>{{ _('Error:') }}</strong> {{ status.task_info.error.message }}
+                    {% for error_key, error_value in status.task_info.error.iteritems() %}
+                        {% if error_key != "message" and error_value %}
+                            <br>
+                            <strong>{{ error_key }}</strong>:
+                            {{ error_value }}
+                        {% endif %}
+                    {% endfor %}
+                {% elif status.task_info.error is iterable %}
+                    <strong>{{ _('Error traceback:') }}</strong>
+                    <pre>{{ ''.join(status.task_info.error) }}</pre>
+                {% endif %}
+            </div>
+        {% endif %}
+
+        <table class="table table-bordered">
+            <colgroup>
+                <col width="150">
+                <col>
+            </colgroup>
+            <tr>
+                <th>{{ _('Status') }}</th>
+                <td>{{ h.xloader_status_description(status) }}</td>
+            </tr>
+            <tr>
+                <th>{{ _('Last updated') }}</th>
+                {% if status.status %}
+                    <td><span class="date" title="{{ h.render_datetime(status.last_updated, with_hours=True) }}">{{ h.time_ago_from_timestamp(status.last_updated) }}</span>
+                    </td>
+                {% else %}
+                    <td>{{ _('Never') }}</td>
+                {% endif %}
+            </tr>
+        </table>
+
+        {% if status.status and status.task_info and show_table %}
+            <h3>{{ _('Upload Log') }}</h3>
+            <ul class="activity">
+                {% for item in status.task_info.logs %}
+                    {% set icon = 'ok' if item.level == 'INFO' else 'exclamation' %}
+                    {% set class = ' failure' if icon == 'exclamation' else ' success' %}
+                    {% set popover_content = 'test' %}
+                    <li class="item no-avatar{{ class }}">
+                        <i class="fa icon fa-{{ icon }}"></i>
+                        <p>
+                            {% for line in item.message.strip().split('\n') %}
+                                {{ line | urlize }}<br>
+                            {% endfor %}
+                            <span class="date" title="{{ h.render_datetime(item.timestamp, with_hours=True) }}">
+                                {{ h.time_ago_from_timestamp(item.timestamp) }}
+                                <a href="#" data-target="popover"
+                                   data-content="<dl>{% for key, value in item.iteritems() %}<dt>{{ key }}</dt><dd>{{ h.clean_html(value|string) }}</dd>{% endfor %}</dl>"
+                                   data-html="true">{{ _('Details') }}</a>
+                            </span>
+                        </p>
+                    </li>
+                {% endfor %}
+                <li class="item no-avatar">
+                    <i class="fa icon fa-info"></i>
+                    <p class="muted">{{ _('End of log') }}</p>
+                </li>
+            </ul>
+        {% endif %}
+
+    </form>
+
+{% endblock %}

--- a/ckanext/gobar_theme/templates/xloader/resource_data.html
+++ b/ckanext/gobar_theme/templates/xloader/resource_data.html
@@ -67,7 +67,7 @@
                     {% set icon = 'ok' if item.level == 'INFO' else 'exclamation' %}
                     {% set class = ' failure' if icon == 'exclamation' else ' success' %}
                     {% set popover_content = 'test' %}
-                    <li class="item no-avatar{{ class }}">
+                    <li class="item no-avatar{{ class }} xloader-log">
                         <i class="fa icon fa-{{ icon }}"></i>
                         <p>
                             {% for line in item.message.strip().split('\n') %}

--- a/ckanext/gobar_theme/templates/xloader/resource_data.html
+++ b/ckanext/gobar_theme/templates/xloader/resource_data.html
@@ -67,7 +67,7 @@
                     {% set icon = 'ok' if item.level == 'INFO' else 'exclamation' %}
                     {% set class = ' failure' if icon == 'exclamation' else ' success' %}
                     {% set popover_content = 'test' %}
-                    <li class="item no-avatar{{ class }} xloader-log">
+                    <li class="item no-avatar{{ class }}">
                         <i class="fa icon fa-{{ icon }}"></i>
                         <p>
                             {% for line in item.message.strip().split('\n') %}

--- a/ckanext/gobar_theme/tests/tests_config/test-core.ini
+++ b/ckanext/gobar_theme/tests/tests_config/test-core.ini
@@ -70,7 +70,7 @@ search_backend = sql
 # Change API key HTTP header to something non-standard.
 apikey_header_name = X-Non-Standard-CKAN-API-Key
 
-ckan.plugins = stats hierarchy_display hierarchy_form datastore dcat structured_data seriestiempoarexplorer gobar_theme googleanalytics
+ckan.plugins = stats hierarchy_display hierarchy_form datastore datapusher dcat structured_data seriestiempoarexplorer gobar_theme googleanalytics
 
 # use <strong> so we can check that html is *not* escaped
 ckan.template_head_end = <link rel="stylesheet" href="TEST_TEMPLATE_HEAD_END.css" type="text/css">


### PR DESCRIPTION
Relacionado a datosgobar/portal-base#90.
Mergear después del PR correspondiente a portal-base.

Se debe poder visitar la sección de Datastore en el formulario de edición de recursos si se activa el plugin `ckanext-xloader`.
Además, no se permite navegar en la configuración de Datapusher si su plugin fue desactivado (`/configurar/datapusher`).