### PR TITLE
454 formato fecha metadatos

### DIFF
--- a/ckanext/gobar_theme/helpers/dates.py
+++ b/ckanext/gobar_theme/helpers/dates.py
@@ -1,14 +1,10 @@
 #!coding=utf-8
 import moment
-
-import ckan.lib.helpers as ckan_helpers
 import ckan.lib.formatters as formatters
-
-from dateutil import parser, tz
-from datetime import time
-
+import ckan.lib.helpers as ckan_helpers
 from ckan.common import _
-
+from datetime import time
+from dateutil import parser, tz
 
 
 def convert_iso_string_to_utc(date_string=''):

--- a/ckanext/gobar_theme/helpers/dates.py
+++ b/ckanext/gobar_theme/helpers/dates.py
@@ -1,8 +1,12 @@
 #!coding=utf-8
-from datetime import time
 import moment
-from dateutil import parser, tz
+
 import ckan.lib.helpers as ckan_helpers
+import ckan.lib.formatters as formatters
+
+from dateutil import parser, tz
+from datetime import time
+
 from ckan.common import _
 
 
@@ -35,6 +39,7 @@ def render_ar_datetime(datetime_):
     datetime_ = ckan_helpers._datestamp_to_datetime(convert_iso_string_to_utc(datetime_))
     if not datetime_:
         return ''
-    return _('{day} de {month} de {year}').format(year=datetime_.year,
-                                                  month=datetime_.month,
-                                                  day=datetime_.day)
+    return _('{day} de {month} de {year}').format(
+        year=datetime_.year,
+        month=formatters._MONTH_FUNCTIONS[datetime_.month - 1]().lower(),
+        day=datetime_.day)

--- a/ckanext/gobar_theme/helpers/dates.py
+++ b/ckanext/gobar_theme/helpers/dates.py
@@ -1,10 +1,12 @@
 #!coding=utf-8
+from datetime import time
+from dateutil import parser, tz
+
 import moment
+
 import ckan.lib.formatters as formatters
 import ckan.lib.helpers as ckan_helpers
 from ckan.common import _
-from datetime import time
-from dateutil import parser, tz
 
 
 def convert_iso_string_to_utc(date_string=''):

--- a/ckanext/gobar_theme/tests/tests_helpers.py
+++ b/ckanext/gobar_theme/tests/tests_helpers.py
@@ -3,6 +3,7 @@
 import os
 import json
 import urllib2
+import pylons
 import nose.tools as nt
 import ckan.tests.factories as factories
 import ckanext.gobar_theme.helpers as gobar_helpers
@@ -10,7 +11,10 @@ from mock import patch
 from ckan.model import license
 from ckanext.gobar_theme.tests import TestAndino
 from ckanext.gobar_theme.tests.TestAndino import get_test_theme_config
+from paste.registry import RegistryManager
 import ckanext.gobar_theme.tests.tools.organizations_manager as orgs_manager
+import ckanext.gobar_theme.tests.tools.constants as constants
+
 
 
 class TestHelpers(TestAndino.TestAndino):
@@ -92,3 +96,54 @@ class TestLicenseHelpers(TestHelpers):
     def test_license_title_search_returns_correct_title(self):
         nt.assert_equals(gobar_helpers.get_license_title('odc-pddl'),
                          u'Open Data Commons Public Domain Dedication and Licence 1.0 (PDDL)')
+
+
+@patch("ckan.lib.formatters._MONTH_FUNCTIONS", constants.MONTH_FUNCTIONS)
+class TestDateHelpers(TestHelpers):
+
+    def test_timezones_are_handled_correctly(self):
+        datetime_str = '2018-01-29T14:14:09.291510-03:00'
+        expected = '29 de enero de 2018'
+        res = gobar_helpers.render_ar_datetime(datetime_str)
+        nt.assert_equals(expected, res)
+
+    def test_dates_change_correctly(self):
+        buenos_aires = '2018-03-29T22:14:09.291510-03:00'
+        expected = '30 de marzo de 2018'
+        res = gobar_helpers.render_ar_datetime(buenos_aires)
+        nt.assert_equals(expected, res)
+
+        moscow = '2018-04-29T01:14:09.291510+03:00'
+        expected = '28 de abril de 2018'
+        res = gobar_helpers.render_ar_datetime(moscow)
+        nt.assert_equals(expected, res)
+
+    def test_datetimes_without_timezones(self):
+        no_timezone_string = '2018-05-29T22:14:09.291510'
+        expected = '29 de mayo de 2018'
+        res = gobar_helpers.render_ar_datetime(no_timezone_string)
+        nt.assert_equals(expected, res)
+
+    def test_datetimes_without_microseconds_are_handled_correctly(self):
+        datetime_str = '2018-10-29T14:14:09-03:00'
+        expected = '29 de octubre de 2018'
+        res = gobar_helpers.render_ar_datetime(datetime_str)
+        nt.assert_equals(expected, res)
+
+    def test_datetimes_without_seconds_are_handled_correctly(self):
+        datetime_str = '2018-11-29T14:14-03:00'
+        expected = '29 de noviembre de 2018'
+        res = gobar_helpers.render_ar_datetime(datetime_str)
+        nt.assert_equals(expected, res)
+
+    def test_date_strings(self):
+        date = '2018-12-29'
+        expected = '29 de diciembre de 2018'
+        res = gobar_helpers.render_ar_datetime(date)
+        nt.assert_equals(expected, res)
+
+    def test_invalid_strings(self):
+        invalid = 'AnInvalidString'
+        expected = ''
+        res = gobar_helpers.render_ar_datetime(invalid)
+        nt.assert_equals(expected, res)

--- a/ckanext/gobar_theme/tests/tools/constants.py
+++ b/ckanext/gobar_theme/tests/tools/constants.py
@@ -1,0 +1,14 @@
+MONTH_FUNCTIONS = [
+    (lambda: 'enero'),
+    (lambda: 'febrero'),
+    (lambda: 'marzo'),
+    (lambda: 'abril'),
+    (lambda: 'mayo'),
+    (lambda: 'junio'),
+    (lambda: 'julio'),
+    (lambda: 'agosto'),
+    (lambda: 'septiembre'),
+    (lambda: 'octubre'),
+    (lambda: 'noviembre'),
+    (lambda: 'diciembre'),
+]


### PR DESCRIPTION
Closes #454 

- Revierto el cambio del [refactor previo](https://github.com/datosgobar/portal-andino-theme/commit/2ee53c25e4beaff3441e8d589320fb575d17e57e#diff-b539d8fc905f7eac9f69d3f8c0729d8dL80) llamando al formatter de ckan
- Agrego tests del `render_ar_datetime`